### PR TITLE
Add a `footer` option to the new command. 

### DIFF
--- a/features/new.feature
+++ b/features/new.feature
@@ -43,11 +43,13 @@ Feature: create a template for a new zendesk app
   <h3>{{setting "name"}}</h3>
 </header>
 <section data-main/>
+
 <footer>
   <a href="mailto:{{author.email}}">
     {{author.name}}
   </a>
 </footer>
+
 </div>
 """
     And the app file "tmp/aruba/translations/en.json" is created with:
@@ -58,4 +60,21 @@ Feature: create a template for a new zendesk app
     "name":         "Buddha Machine"
   }
 }
+"""
+
+  Scenario: create a template for a new zendesk app by running 'zat new --no-footer' command
+    Given an app directory "tmp/aruba" exists
+    When I run "zat new --no-footer" command with the following details:
+      | author name  | John Citizen      |
+      | author email | john@example.com  |
+      | app name     | John Test App     |
+    Then the app file "tmp/aruba/templates/layout.hdbs" is created with:
+    """
+<header>
+  <span class="logo"/>
+  <h3>{{setting "name"}}</h3>
+</header>
+<section data-main/>
+
+</div>
 """

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -17,7 +17,10 @@ module ZendeskAppsTools
     source_root File.expand_path(File.join(File.dirname(__FILE__), "../.."))
 
     desc "new", "Generate a new app"
+    method_option :footer, :type => :boolean, :default => true
     def new
+      @footer = options[:footer]
+
       puts "Enter this app author's name:"
       @author_name = get_value_from_stdin(/^\w.*$/, "Invalid name, try again:")
 
@@ -179,4 +182,3 @@ module ZendeskAppsTools
     end
   end
 end
-

--- a/template/templates/layout.hdbs.tt
+++ b/template/templates/layout.hdbs.tt
@@ -3,9 +3,11 @@
   <h3>{{setting "name"}}</h3>
 </header>
 <section data-main/>
+<% if @footer %>
 <footer>
   <a href="mailto:{{author.email}}">
     {{author.name}}
   </a>
 </footer>
+<% end %>
 </div>


### PR DESCRIPTION
I'm building a lot of Zendesk Apps right now and I find that the footer takes too much space, so I made it optional.

We can now run `zat new --no-footer` and generate a 'templates/layout.hdbs' without the `<footer>` tag.

Thanks a lot for this gem!
