### PR TITLE
[APPS-933] - As a ZAT user, I want "ZAT new" to give me the current version in my default manifest.json

### DIFF
--- a/app_template/manifest.json.tt
+++ b/app_template/manifest.json.tt
@@ -7,5 +7,5 @@
   "defaultLocale": "en",
   "private": true,
   "location": "ticket_sidebar",
-  "frameworkVersion": "0.5"
+  "frameworkVersion": "<%= @framework_version %>"
 }

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -42,6 +42,8 @@ module ZendeskAppsTools
         end
       end
 
+      @framework_version = AppVersion::CURRENT
+
       directory('app_template', @app_dir)
     end
 


### PR DESCRIPTION
:koala: :+1: 

This PR replaces the hard-coded version output to the default manifest via `zat new` with whatever the value of `ZendeskAppsSupport::AppVersion::CURRENT`... currently is. 

/cc @zendesk/quokka 
