### PR TITLE
Add gems from Gemfile to load path for bin/zat

### DIFF
--- a/bin/zat
+++ b/bin/zat
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+
+# add Gems from Gemfile to the loadpath (for developing ZAS locally)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile", __FILE__)
+require 'bundler/setup'
+
 lib_dir = File.expand_path('../../lib', __FILE__)
 $LOAD_PATH << lib_dir unless $LOAD_PATH.include?(lib_dir)
 require 'zendesk_apps_tools'


### PR DESCRIPTION
Currently, `bin/zat` doesn't set up its loadpaths correctly (unless you do bundle exec), so it was using the system's zendesk_apps_support gem (if it was installed).

This change makes it bin/zat use the zendesk_apps_support specified in the Gemfile, so you can develop with it locally (without having to run it from the ZAT directory, e.g. if you want to test out how it serves an app).
