### PR TITLE
Bump ZAS to v1.13.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'zendesk_apps_support', :git => 'https://github.com/zendesk/zendesk_apps_support.git', :ref => 'v1.13.1'
+gem 'zendesk_apps_support', :git => 'https://github.com/zendesk/zendesk_apps_support.git', :ref => 'v1.13.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/zendesk/zendesk_apps_support.git
-  revision: 83fa8c96f9af1c5cfd09d78d0ace7ab601d16699
-  ref: v1.13.1
+  revision: 2bdd061f89c8e187fb868992917d751105b783c7
+  ref: v1.13.2
   specs:
-    zendesk_apps_support (1.13.1)
+    zendesk_apps_support (1.13.2)
       erubis
       i18n
       jshintrb (= 0.2.4)
@@ -19,7 +19,7 @@ PATH
       rubyzip (~> 0.9.1)
       sinatra (~> 1.3.4)
       thor (~> 0.18.0)
-      zendesk_apps_support (~> 1.13.1)
+      zendesk_apps_support (~> 1.13.2)
 
 GEM
   remote: https://rubygems.org/

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rubyzip',     '~> 0.9.1'
   s.add_runtime_dependency 'sinatra',     '~> 1.3.4'
   s.add_runtime_dependency 'faraday',     '~> 0.8.7'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 1.13.1'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 1.13.2'
 
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'aruba'


### PR DESCRIPTION
Use latest version of ZAS which contains updated validations

/cc @zendesk/quokka 
