### PR TITLE
Bump ZAS to v1.13.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'zendesk_apps_support', :git => 'https://github.com/zendesk/zendesk_apps_support.git', :ref => 'v1.13.2'
+gem 'zendesk_apps_support', :git => 'https://github.com/zendesk/zendesk_apps_support.git', :ref => 'v1.13.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,14 @@
 GIT
   remote: https://github.com/zendesk/zendesk_apps_support.git
-  revision: 2bdd061f89c8e187fb868992917d751105b783c7
-  ref: v1.13.2
+  revision: 83188bff8c4e4ca1b099f9d0c96ccc9748a113c1
+  ref: v1.13.3
   specs:
-    zendesk_apps_support (1.13.2)
+    zendesk_apps_support (1.13.3)
       erubis
       i18n
       jshintrb (= 0.2.4)
       json
+      json-stream
       multi_json
       sass
 
@@ -19,7 +20,7 @@ PATH
       rubyzip (~> 0.9.1)
       sinatra (~> 1.3.4)
       thor (~> 0.18.0)
-      zendesk_apps_support (~> 1.13.2)
+      zendesk_apps_support (~> 1.13.3)
 
 GEM
   remote: https://rubygems.org/
@@ -55,6 +56,7 @@ GEM
       multi_json (>= 1.3)
       rake
     json (1.8.1)
+    json-stream (0.1.3)
     multi_json (1.7.9)
     multi_test (0.0.1)
     multipart-post (1.2.0)

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rubyzip',     '~> 0.9.1'
   s.add_runtime_dependency 'sinatra',     '~> 1.3.4'
   s.add_runtime_dependency 'faraday',     '~> 0.8.7'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 1.13.2'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 1.13.3'
 
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'aruba'


### PR DESCRIPTION
:koala::+1:

Bump ZAS to latest version, which includes validation updates

/cc @zendesk/quokka
