### PR TITLE
making 1.0 default framework version

### DIFF
--- a/app_template/manifest.json.tt
+++ b/app_template/manifest.json.tt
@@ -8,5 +8,5 @@
   "private": true,
   "location": "ticket_sidebar",
   "version": "1.0",
-  "frameworkVersion": "0.5"
+  "frameworkVersion": "1.0"
 }

--- a/features/new.feature
+++ b/features/new.feature
@@ -32,7 +32,7 @@ Feature: create a template for a new zendesk app
   "private": true,
   "location": "ticket_sidebar",
   "version": "1.0",
-  "frameworkVersion": "0.5"
+  "frameworkVersion": "1.0"
 }
 """
     And the app file "tmp/aruba/app.js" is created with:


### PR DESCRIPTION
This PR intends to make 1.0 the default version when running 'zat new'

cc @zendesk/quokka 
