### PR TITLE
[PORTSEA] Add CORS support for static assets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ PATH
       faraday (~> 0.8.7)
       rubyzip (~> 0.9.1)
       sinatra (~> 1.3.4)
+      sinatra-cross_origin (~> 0.3.1)
       thor (~> 0.18.0)
       zendesk_apps_support (~> 1.11.0)
 
@@ -59,7 +60,7 @@ GEM
     multi_test (0.0.1)
     multipart-post (1.2.0)
     rack (1.5.2)
-    rack-protection (1.5.1)
+    rack-protection (1.5.2)
       rack
     rake (10.1.1)
     rspec (2.12.0)
@@ -77,6 +78,7 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.3)
       tilt (~> 1.3, >= 1.3.3)
+    sinatra-cross_origin (0.3.2)
     thor (0.18.1)
     tilt (1.4.1)
     webmock (1.11.0)

--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -1,13 +1,22 @@
 require 'sinatra/base'
+require 'sinatra/cross_origin'
 require 'zendesk_apps_support/package'
 
 module ZendeskAppsTools
   class Server < Sinatra::Base
+    register Sinatra::CrossOrigin
+
     set :public_folder, Proc.new {"#{settings.root}/assets"}
+    set :allow_origin, :any
 
     get '/app.js' do
       content_type 'text/javascript'
       ZendeskAppsSupport::Package.new(settings.root).readified_js(nil, 0, "http://localhost:#{settings.port}/", settings.parameters)
+    end
+
+    def static!
+      cross_origin
+      super
     end
 
   end

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'thor',        '~> 0.18.0'
   s.add_runtime_dependency 'rubyzip',     '~> 0.9.1'
   s.add_runtime_dependency 'sinatra',     '~> 1.3.4'
+  s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'faraday',     '~> 0.8.7'
   s.add_runtime_dependency 'zendesk_apps_support', '~> 1.11.0'
 


### PR DESCRIPTION
:koala: :tennis: :+1: 

Currently there are no headers that allow the assets to be loaded over XHR from the Zendesk domain. When the app is uploaded assets are served from the same domain so this is not a problem, however when running under `zat serve` it is using a different origin. 

This PR adds the Access-Control-Allow-Origin headers and others by using the sinatra-cross_origin gem to get around this issue.

/cc @zendesk/quokka 
