### PR TITLE
Support for -p as an alias for —path.

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -14,8 +14,8 @@ module ZendeskAppsTools
 
   class Command < Thor
 
-    SHARED_OPTIONS      = {
-      :path =>  './',
+    SHARED_OPTIONS = {
+      ['path', '-p'] => './',
       :clean => false
     }
 


### PR DESCRIPTION
I’m a lazy programmer and don’t like typing. All it does is support -p instead of typing --path=
