### PR TITLE
Bump ZAS to v1.15.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'zendesk_apps_support', :git => 'https://github.com/zendesk/zendesk_apps_support.git', :ref => 'v1.14.4'
+gem 'zendesk_apps_support', :git => 'https://github.com/zendesk/zendesk_apps_support.git', :ref => 'v1.15.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/zendesk/zendesk_apps_support.git
-  revision: 95a735773d190121505b99b468f8a016446979ee
-  ref: v1.14.4
+  revision: f46c5e60c279fdb95e7552a45568cb5f146eb85f
+  ref: v1.15.0
   specs:
-    zendesk_apps_support (1.14.4)
+    zendesk_apps_support (1.15.0)
       erubis
       i18n
       image_size
@@ -21,7 +21,7 @@ PATH
       rubyzip (~> 0.9.1)
       sinatra (~> 1.3.4)
       thor (~> 0.18.0)
-      zendesk_apps_support (~> 1.14.4)
+      zendesk_apps_support (~> 1.15.0)
 
 GEM
   remote: https://rubygems.org/
@@ -65,7 +65,7 @@ GEM
     rack (1.5.2)
     rack-protection (1.5.3)
       rack
-    rake (10.2.2)
+    rake (10.3.1)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)
       rspec-expectations (~> 2.12.0)
@@ -76,7 +76,7 @@ GEM
     rspec-mocks (2.12.2)
     rubyzip (0.9.9)
     safe_yaml (0.9.7)
-    sass (3.3.5)
+    sass (3.3.7)
     sinatra (1.3.6)
       rack (~> 1.4)
       rack-protection (~> 1.3)

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rubyzip',     '~> 0.9.1'
   s.add_runtime_dependency 'sinatra',     '~> 1.3.4'
   s.add_runtime_dependency 'faraday',     '~> 0.8.7'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 1.14.4'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 1.15.0'
 
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'aruba'


### PR DESCRIPTION
Bump ZAS to v1.15.0 to include CommonJS support

/cc @zendesk/quokka 
### RISKS
- None
