### PR TITLE
Allow password to be stored in .zat cache

### DIFF
--- a/lib/zendesk_apps_tools/api_connection.rb
+++ b/lib/zendesk_apps_tools/api_connection.rb
@@ -6,14 +6,9 @@ module ZendeskAppsTools
     def prepare_api_auth
       @subdomain ||= get_cache('subdomain') || get_value_from_stdin('Enter your Zendesk subdomain or full Zendesk URL:')
       @username  ||= get_cache('username') || get_value_from_stdin('Enter your username:')
+      @password  ||= get_cache('password') || get_password_from_stdin('Enter your password:')
 
-      unless @password
-        print 'Enter your password: '
-        @password ||= STDIN.noecho(&:gets).chomp
-        puts
-
-        set_cache 'subdomain' => @subdomain, 'username' => @username
-      end
+      set_cache 'subdomain' => @subdomain, 'username' => @username
     end
 
     def get_full_url

--- a/lib/zendesk_apps_tools/common.rb
+++ b/lib/zendesk_apps_tools/common.rb
@@ -29,5 +29,12 @@ module ZendeskAppsTools
 
       return input
     end
+
+    def get_password_from_stdin(prompt, opts = {})
+      print "#{prompt} "
+      password = STDIN.noecho(&:gets).chomp
+      puts
+      password
+    end
   end
 end


### PR DESCRIPTION
:koala:

Allow password to be stored in .zat cache

/cc @zendesk/quokka
### Risks
- Passwords can be stored by users in .zat file which is not protected
