### PR TITLE
Allow setting of the app id

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -88,11 +88,13 @@ module ZendeskAppsTools
     DEFAULT_SERVER_PATH = './'
     DEFAULT_CONFIG_PATH = './settings.yml'
     DEFAULT_SERVER_PORT = 4567
+    DEFAULT_APP_ID = 0
 
     desc 'server', 'Run a http server to serve the local app'
     method_option :path, default: DEFAULT_SERVER_PATH, required: false, aliases: '-p'
     method_option :config, default: DEFAULT_CONFIG_PATH, required: false, aliases: '-c'
     method_option :port, default: DEFAULT_SERVER_PORT, required: false
+    method_option :app_id, default: DEFAULT_APP_ID, required: false
     def server
       setup_path(options[:path])
       manifest = app_package.manifest_json
@@ -112,6 +114,7 @@ module ZendeskAppsTools
         server.set :parameters, settings
         server.set :manifest, manifest[:parameters]
         server.set :config, options[:config]
+        server.set :app_id, options[:app_id]
         server.run!
       end
     end

--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -18,7 +18,7 @@ module ZendeskAppsTools
         end
       end
 
-      ZendeskAppsSupport::Package.new(settings.root).readified_js(nil, 0, "http://localhost:#{settings.port}/", settings.parameters)
+      ZendeskAppsSupport::Package.new(settings.root).readified_js(nil, settings.app_id, "http://localhost:#{settings.port}/", settings.parameters)
     end
   end
 end


### PR DESCRIPTION
:koala:

Allow setting of the app id so we can use ZAT for testing existing installations of apps that use Secure Requests without having to re-upload them. ZAS uses the same id for the installation as well, so oddly you'll usually want to use the installation id and not the app id for the app id. :/

/cc @zendesk/quokka

### Risks
 - None