### PR TITLE
build in a pseudotranslate function

### DIFF
--- a/spec/fixture/i18n_app_pseudotranslate/translations/en.json
+++ b/spec/fixture/i18n_app_pseudotranslate/translations/en.json
@@ -1,0 +1,21 @@
+{
+  "app": {
+    "package" : "my_app",
+    "abc" : {
+      "title" : "description for abc field",
+      "value" : "value of \"abc\""
+    }
+  },
+  "a": {
+    "a1": {
+      "title": "description for a1 field",
+      "value": "value of a1"
+    },
+    "b": {
+      "b1": {
+        "title": "description for b1 field",
+        "value": "value of b1"
+      }
+    }
+  }
+}

--- a/spec/fixture/i18n_app_pseudotranslate/translations/expected.json
+++ b/spec/fixture/i18n_app_pseudotranslate/translations/expected.json
@@ -1,0 +1,21 @@
+{
+  "app": {
+    "package": "my_app",
+    "abc": {
+      "title": "description for abc field",
+      "value": "[日本value of \"abc\"éñđ]"
+    }
+  },
+  "a": {
+    "a1": {
+      "title": "description for a1 field",
+      "value": "[日本value of a1éñđ]"
+    },
+    "b": {
+      "b1": {
+        "title": "description for b1 field",
+        "value": "[日本value of b1éñđ]"
+      }
+    }
+  }
+}

--- a/spec/lib/zendesk_apps_tools/translate_spec.rb
+++ b/spec/lib/zendesk_apps_tools/translate_spec.rb
@@ -40,7 +40,7 @@ describe ZendeskAppsTools::Translate do
       expect(context.nest_translations_hash(translations, 'txt.apps.my_app.')).to eq(result)
     end
 
-    context 'with a mix of nested and unnested keys' do
+    describe 'with a mix of nested and unnested keys' do
       it 'returns a mixed depth hash' do
         translations = {
           'app.description' => 'This app is awesome',
@@ -100,6 +100,20 @@ describe ZendeskAppsTools::Translate do
       end
 
       translate.update(test)
+    end
+  end
+
+  describe "#pseudotranslate" do
+    it 'generates a json file for the specified locale' do
+      root = 'spec/fixture/i18n_app_pseudotranslate'
+      target_json = "#{root}/translations/fr.json"
+      File.delete(target_json) if File.exist?(target_json)
+      translate = ZendeskAppsTools::Translate.new
+      translate.setup_path(root)
+      translate.pseudotranslate
+
+      expect(File.read(target_json)).to eq(File.read("#{root}/translations/expected.json"))
+      File.delete(target_json) if File.exist?(target_json)
     end
   end
 end


### PR DESCRIPTION
Build in a pseudotranslate function.  This function is similar to what Rosetta does for psuedotranslation.  It simply takes the English string and adds some unique markers to the beginning and end of the string. This allows devs to easily find them, and helps with spacing requirements. 

/cc @princemaple @pdeuter 

@princemaple can you tag others if necessary? 

### References
 - Jira link: https://zendesk.atlassian.net/browse/LOCAL-580

### Risks
 - Low. This just adds another command to the translate library. 