### PR TITLE
pass locale to ZAS Package

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       rubyzip (~> 0.9.1)
       sinatra (~> 1.3.4)
       thor (~> 0.18.0)
-      zendesk_apps_support (~> 1.17.0)
+      zendesk_apps_support (~> 1.17.3)
 
 GEM
   remote: https://rubygems.org/
@@ -30,7 +30,7 @@ GEM
       multi_test (>= 0.1.1)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    execjs (2.4.0)
+    execjs (2.5.2)
     faraday (0.8.9)
       multipart-post (~> 1.2.0)
     ffi (1.9.6)
@@ -47,7 +47,7 @@ GEM
     multi_json (1.10.1)
     multi_test (0.1.1)
     multipart-post (1.2.0)
-    rack (1.6.0)
+    rack (1.6.1)
     rack-protection (1.5.3)
       rack
     rake (10.4.2)
@@ -75,7 +75,7 @@ GEM
     webmock (1.20.4)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-    zendesk_apps_support (1.17.2)
+    zendesk_apps_support (1.17.3)
       erubis
       i18n
       image_size

--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -17,9 +17,8 @@ module ZendeskAppsTools
           last_mtime = curr_mtime
         end
       end
-      settings.parameters.merge!(locale: params['locale'])
 
-      ZendeskAppsSupport::Package.new(settings.root).readified_js(nil, settings.app_id, "http://localhost:#{settings.port}/", settings.parameters)
+      ZendeskAppsSupport::Package.new(settings.root).readified_js(nil, settings.app_id, "http://localhost:#{settings.port}/", settings.parameters, params['locale'])
     end
   end
 end

--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -17,13 +17,9 @@ module ZendeskAppsTools
           last_mtime = curr_mtime
         end
       end
-      settings.parameters.merge!( { locale: normalize_locale(params['locale']) } )
+      settings.parameters.merge!(locale: params['locale'])
 
       ZendeskAppsSupport::Package.new(settings.root).readified_js(nil, settings.app_id, "http://localhost:#{settings.port}/", settings.parameters)
-    end
-
-    def normalize_locale(locale)
-      locale.downcase.gsub("-us", "")
     end
   end
 end

--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -17,8 +17,13 @@ module ZendeskAppsTools
           last_mtime = curr_mtime
         end
       end
+      settings.parameters.merge!( { locale: normalize_locale(params['locale']) } )
 
       ZendeskAppsSupport::Package.new(settings.root).readified_js(nil, settings.app_id, "http://localhost:#{settings.port}/", settings.parameters)
+    end
+
+    def normalize_locale(locale)
+      locale.downcase.gsub("-us", "")
     end
   end
 end

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rubyzip',     '~> 0.9.1'
   s.add_runtime_dependency 'sinatra',     '~> 1.3.4'
   s.add_runtime_dependency 'faraday',     '~> 0.8.7'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 1.17.0'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 1.17.3'
 
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'aruba'


### PR DESCRIPTION
Use the locale parameter sent by the classic apps helper. 

/cc @pdeuter @benhass @princemaple 

### References
 - Classic Change: https://github.com/zendesk/zendesk/pull/16964

### Risks
 - Low. Just adding a key into the parameters hash. 