### PR TITLE
Bump ZAS to 1.18.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       rubyzip (~> 0.9.1)
       sinatra (~> 1.3.4)
       thor (~> 0.18.0)
-      zendesk_apps_support (~> 1.17.3)
+      zendesk_apps_support (~> 1.18.0)
 
 GEM
   remote: https://rubygems.org/
@@ -75,7 +75,7 @@ GEM
     webmock (1.20.4)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-    zendesk_apps_support (1.17.3)
+    zendesk_apps_support (1.18.0)
       erubis
       i18n
       image_size

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rubyzip',     '~> 0.9.1'
   s.add_runtime_dependency 'sinatra',     '~> 1.3.4'
   s.add_runtime_dependency 'faraday',     '~> 0.8.7'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 1.17.3'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 1.18.0'
 
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'aruba'


### PR DESCRIPTION
:koala:

List of changes is [here](https://github.com/zendesk/zendesk_apps_support/compare/v1.17.2...v1.18.0)

0.5 apps will now be deprecated, i.e. we will still serve apps targeting the deprecated version, but newly created or updated apps CANNOT target it

/cc @zendesk/quokka

### Risks
 - Forcing people to update their apps, making some developers angry