### PR TITLE
Add note about server limitations

### DIFF
--- a/doc/tools.md
+++ b/doc/tools.md
@@ -4,7 +4,7 @@ The Zendesk app tools (ZAT) is a collection of local development tools that simp
 
 ZAT is a [Ruby gem](http://rubygems.org/gems/zendesk_apps_tools) -- a self-contained package of Ruby code that extends Ruby. You don't need to know Ruby to use the tools but you do need to install Ruby to install the gem.
 
-To install the tools, see [Installing and using the Zendesk apps tools](https://support.zendesk.com/entries/25079228). See the [known issues](https://support.zendesk.com/entries/42600698) if you run into any problems installing or using the tools.
+To install the tools, see [Installing and using the Zendesk apps tools](https://support.zendesk.com/hc/en-us/articles/203691236). See the [known issues](https://support.zendesk.com/hc/en-us/articles/203691376) if you run into any problems installing or using the tools.
 
 The tools consist of the following commands.
 
@@ -16,7 +16,7 @@ Creates all the files necessary to start building a Zendesk app.
 
 Example:
 
-![image](http://cdn.zendesk.com/images/documentation/apps/zat_mac_cmd_new.png)
+![image]https://zen-marketing-documentation.s3.amazonaws.com/docs/en/zat_mac_cmd_new.png)
 
 ### Validate
 
@@ -28,7 +28,9 @@ Runs a suite of validation tests against your app.
 
 Starts a local HTTP server that lets you run and test your apps locally.
 
-Follow these steps to run an app locally: 
+Note: [Secure requests](./requests#secure_requests) and [app requirements](./app_requirements) don't work when running the app locally. See [ZAT server limitations](https://support.zendesk.com/hc/en-us/articles/203691236#topic_ux4_lv3_ks) for more information and a workaround.
+
+Follow these steps to run an app locally:
 
 1. Use a command-line interface to navigate to the folder containing the app you want to test.
 
@@ -46,16 +48,16 @@ Follow these steps to run an app locally:
 
 	<tt>https://subdomain.zendesk.com/agent/tickets/321321?zat=true</tt>
 
-- Click the Reload Apps icon in the upper-right side of the Apps panel to load your local app.	
+- Click the Reload Apps icon in the upper-right side of the Apps panel to load your local app.
 
 	**Note**: If nothing happens and you're using Chrome or Firefox, click the shield icon on the Address Bar and agree to load an unsafe script (Chrome) or to disable protection on the page (Firefox).
-	
+
 To stop the server, switch to your command-line interface and press Control+C.
 
 
 ### Package
 
-Creates a zip file that you can [upload and install](https://support.zendesk.com/entries/25221787) in Zendesk.
+Creates a zip file that you can [upload and install](hhttps://support.zendesk.com/hc/en-us/articles/203691246) in Zendesk.
 
     $ zat package
 
@@ -63,7 +65,7 @@ The command saves the zip file in a folder named <tt>tmp</tt>.
 
 Example:
 
-![image](http://cdn.zendesk.com/images/documentation/apps/zat_mac_cmd_package.png)
+![image](https://zen-marketing-documentation.s3.amazonaws.com/docs/en/zat_mac_cmd_package.png)
 
 ### Clean
 


### PR DESCRIPTION
**Description**

Not _deja vu_. The ZAT doc is in a different repo from the rest of the framework docs.

* Add a ZAT limitations with secure requests and requirements to the section about the ZAT server
* Refresh some old links with new S3 and HC links

**Reference**

* [Ticket 1131894](https://support.zendesk.com/agent/tickets/1131894)

@maximeprades @pmgrove @angiesaurus