### PR TITLE
Developer docs enhancement

### DIFF
--- a/doc/tools.md
+++ b/doc/tools.md
@@ -92,17 +92,7 @@ mySetting: test value
 
 With the first file, you'd start the server with `zat server -c settings.json`. With the second file, you'd start it with `zat server -c`.
 
-To access the settings from your JavaScript code, use the `setting('name')` framework method to retrieve the value of a setting. Example:
-
-```javascript
-alert( this.setting('mySetting') );
-```
-
-To access the settings from your Handlebars templates, use the `{{setting 'name'}}` [template helper](./templates#setting-name). Example:
-
-```html
-<p>Setting Value: {{setting 'mySetting'}}</p>
-```
+For details on how to access the settings values from your JavaScript code or Handlebar templates, see [Retrieving setting values](https://developer.zendesk.com/apps/docs/agent/settings#retrieving-setting-values).
 
 ### Package
 

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -92,7 +92,7 @@ mySetting: test value
 
 With the first file, you'd start the server with `zat server -c settings.json`. With the second file, you'd start it with `zat server -c`.
 
-For details on how to access the settings values from your JavaScript code or Handlebar templates, see [Retrieving setting values](https://developer.zendesk.com/apps/docs/agent/settings#retrieving-setting-values).
+For details on how to access the settings values from your JavaScript code or Handlebar templates, see [Retrieving setting values](settings#retrieving-settings-values).
 
 ### Package
 

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -98,7 +98,7 @@ To access the settings from your JavaScript code, use the `setting('name')` fram
 alert( this.setting('mySetting') );
 ```
 
-To access the seetings from your Handlebars templates, use the `{{setting 'name'}}` [template helper](./templates#setting-name). Example:
+To access the setings from your Handlebars templates, use the `{{setting 'name'}}` [template helper](./templates#setting-name). Example:
 
 ```html
 <a href="{{setting 'mySetting'}}" />

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -98,7 +98,7 @@ To access the settings from your JavaScript code, use the `setting('name')` fram
 alert( this.setting('mySetting') );
 ```
 
-To access the setings from your Handlebars templates, use the `{{setting 'name'}}` [template helper](./templates#setting-name). Example:
+To access the settings from your Handlebars templates, use the `{{setting 'name'}}` [template helper](./templates#setting-name). Example:
 
 ```html
 <a href="{{setting 'mySetting'}}" />

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -92,6 +92,22 @@ mySetting: test value
 
 With the first file, you'd start the server with `zat server -c settings.json`. With the second file, you'd start it with `zat server -c`.
 
+You can then make use of the setting value in your JavaScript code or your Handlebars templates.
+
+In your **app.js** code, use the `setting('name')` framework method to retrieve the value of a setting. Example:
+
+```javascript
+alert( this.setting('mySetting') );
+```
+
+The snippet displays a JavaScript alert box with the value of the `mySetting` setting.
+
+In your templates, use the `{{setting 'name'}}` [template helper](./templates#setting-name). Example:
+
+```html
+<a href="{{setting 'mySetting'}}" />
+```
+
 ### Package
 
 Creates a zip file that you can [upload and install](https://support.zendesk.com/hc/en-us/articles/203691246) in Zendesk.

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -101,7 +101,7 @@ alert( this.setting('mySetting') );
 To access the settings from your Handlebars templates, use the `{{setting 'name'}}` [template helper](./templates#setting-name). Example:
 
 ```html
-<p>mySetting Value: {{setting 'mySetting'}}</p>
+<p>Setting Value: {{setting 'mySetting'}}</p>
 ```
 
 ### Package

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -92,17 +92,13 @@ mySetting: test value
 
 With the first file, you'd start the server with `zat server -c settings.json`. With the second file, you'd start it with `zat server -c`.
 
-You can then make use of the setting value in your JavaScript code or your Handlebars templates.
-
-In your **app.js** code, use the `setting('name')` framework method to retrieve the value of a setting. Example:
+To access the settings from your JavaScript code, use the `setting('name')` framework method to retrieve the value of a setting. Example:
 
 ```javascript
 alert( this.setting('mySetting') );
 ```
 
-The snippet displays a JavaScript alert box with the value of the `mySetting` setting.
-
-In your templates, use the `{{setting 'name'}}` [template helper](./templates#setting-name). Example:
+To access the seetings from your Handlebars templates, use the `{{setting 'name'}}` [template helper](./templates#setting-name). Example:
 
 ```html
 <a href="{{setting 'mySetting'}}" />

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -101,7 +101,7 @@ alert( this.setting('mySetting') );
 To access the settings from your Handlebars templates, use the `{{setting 'name'}}` [template helper](./templates#setting-name). Example:
 
 ```html
-<a href="{{setting 'mySetting'}}" />
+<p>mySetting Value: {{setting 'mySetting'}}</p>
 ```
 
 ### Package


### PR DESCRIPTION
:koala:

I was walking through the app developer docs for the first time and working the examples.

When I hit this blurb on how to pass parameters to the app via the -c parameter I fell down a 45 min rabbit hole where I tried to figure out how to reference/use values passed as parameters/settings. 

Once I found the Settings page it was pretty clear - however adding a quick example here might help others to not stumble on this.

/cc @zendesk/quokka, @chucknado 

### Steps to reproduce
Visit the production page:
https://developer.zendesk.com/apps/docs/agent/tools

### Risks
 - None