### PR TITLE
Disable frame_options protection

### DIFF
--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -3,6 +3,7 @@ require 'zendesk_apps_support/package'
 
 module ZendeskAppsTools
   class Server < Sinatra::Base
+    set :protection, :except => :frame_options
     set :public_folder, proc { "#{settings.root}/assets" }
     last_mtime = Time.new(0)
 


### PR DESCRIPTION
:koala:

This allows developers to include an iframe from the assets folder when using ZAT.

/cc @zendesk/quokka @fandoweb 

### Risks
 - None