### PR TITLE
Allow packing .scss file

### DIFF
--- a/lib/zendesk_apps_tools/package_helper.rb
+++ b/lib/zendesk_apps_tools/package_helper.rb
@@ -19,7 +19,7 @@ module ZendeskAppsTools
           if File.symlink? file.absolute_path
             path = File.expand_path(File.readlink(file.absolute_path), File.dirname(file.absolute_path))
           end
-          if file.basename == 'app.scss'
+          if file.to_s == 'app.scss'
             relative_path = relative_path.sub 'app.scss', 'app.css'
           end
           zipfile.add(relative_path, app_dir.join(path).to_s)

--- a/lib/zendesk_apps_tools/package_helper.rb
+++ b/lib/zendesk_apps_tools/package_helper.rb
@@ -11,14 +11,18 @@ module ZendeskAppsTools
     def zip(archive_path)
       Zip::ZipFile.open(archive_path, 'w') do |zipfile|
         app_package.files.each do |file|
-          path = file.relative_path
+          relative_path = file.relative_path
+          path = relative_path
           say_status 'package', "adding #{path}"
 
           # resolve symlink to source path
           if File.symlink? file.absolute_path
             path = File.expand_path(File.readlink(file.absolute_path), File.dirname(file.absolute_path))
           end
-          zipfile.add(file.relative_path, app_dir.join(path).to_s)
+          if file.basename == 'app.scss'
+            relative_path = relative_path.sub 'app.scss', 'app.css'
+          end
+          zipfile.add(relative_path, app_dir.join(path).to_s)
         end
       end
     end


### PR DESCRIPTION
Allow packing apps with .scss files.
See zendesk/zendesk_apps_support#109 for additional details on the need for .scss file packing.