### PR TITLE
Make app template use the default i18n format as documented

### DIFF
--- a/app_template/translations/en.json
+++ b/app_template/translations/en.json
@@ -1,54 +1,16 @@
 {
   "app": {
-    "package": "app_name",
-    "description": {
-      "value": "Play the famous zen tunes in your help desk.",
-      "title": "app description"
-    },
-    "name": {
-      "value": "Buddha Machine",
-      "title": "app name"
-    }
+    "description": "Play the famous zen tunes in your help desk.",
+    "name": "Buddha Machine"
   },
-
-  "loading": {
-    "value": "Welcome to this Sample App",
-    "title": "loading placeholder"
-  },
-
+  "loading": "Welcome to this Sample App",
   "fetch": {
-    "done": {
-      "value": "Good",
-      "title": "fetch success"
-    },
-    "fail": {
-      "value": "failed to fetch information from the server",
-      "title": "fetch failure"
-    }
+    "done": "Good",
+    "fail": "failed to fetch information from the server"
   },
-
-  "id": {
-    "value": "ID",
-    "title": "user id"
-  },
-
-  "email": {
-    "value": "Email",
-    "title": "user email"
-  },
-
-  "name": {
-    "value": "Name",
-    "title": "user name"
-  },
-
-  "role": {
-    "value": "Role",
-    "title": "user role"
-  },
-
-  "groups": {
-    "value": "Groups",
-    "title": "user groups"
-  }
+  "id": "ID",
+  "email": "Email",
+  "name": "Name",
+  "role": "Role",
+  "groups": "Groups"
 }

--- a/app_template_iframe/translations/en.json
+++ b/app_template_iframe/translations/en.json
@@ -1,54 +1,16 @@
 {
   "app": {
-    "package": "app_name",
-    "description": {
-      "value": "Play the famous zen tunes in your help desk.",
-      "title": "app description"
-    },
-    "name": {
-      "value": "Buddha Machine",
-      "title": "app name"
-    }
+    "description": "Play the famous zen tunes in your help desk.",
+    "name": "Buddha Machine"
   },
-
-  "loading": {
-    "value": "Welcome to this Sample App",
-    "title": "loading placeholder"
-  },
-
+  "loading": "Welcome to this Sample App",
   "fetch": {
-    "done": {
-      "value": "Good",
-      "title": "fetch success"
-    },
-    "fail": {
-      "value": "failed to fetch information from the server",
-      "title": "fetch failure"
-    }
+    "done": "Good",
+    "fail": "failed to fetch information from the server"
   },
-
-  "id": {
-    "value": "ID",
-    "title": "user id"
-  },
-
-  "email": {
-    "value": "Email",
-    "title": "user email"
-  },
-
-  "name": {
-    "value": "Name",
-    "title": "user name"
-  },
-
-  "role": {
-    "value": "Role",
-    "title": "user role"
-  },
-
-  "groups": {
-    "value": "Groups",
-    "title": "user groups"
-  }
+  "id": "ID",
+  "email": "Email",
+  "name": "Name",
+  "role": "Role",
+  "groups": "Groups"
 }

--- a/features/new.feature
+++ b/features/new.feature
@@ -70,57 +70,19 @@ Feature: create a template for a new zendesk app
      """
  {
    "app": {
-     "package": "app_name",
-     "description": {
-       "value": "Play the famous zen tunes in your help desk.",
-       "title": "app description"
-     },
-     "name": {
-       "value": "Buddha Machine",
-       "title": "app name"
-     }
+     "description": "Play the famous zen tunes in your help desk.",
+     "name": "Buddha Machine"
    },
-
-   "loading": {
-     "value": "Welcome to this Sample App",
-     "title": "loading placeholder"
-   },
-
+   "loading": "Welcome to this Sample App",
    "fetch": {
-     "done": {
-       "value": "Good",
-       "title": "fetch success"
-     },
-     "fail": {
-       "value": "failed to fetch information from the server",
-       "title": "fetch failure"
-     }
+     "done": "Good",
+     "fail": "failed to fetch information from the server"
    },
-
-   "id": {
-     "value": "ID",
-     "title": "user id"
-   },
-
-   "email": {
-     "value": "Email",
-     "title": "user email"
-   },
-
-   "name": {
-     "value": "Name",
-     "title": "user name"
-   },
-
-   "role": {
-     "value": "Role",
-     "title": "user role"
-   },
-
-   "groups": {
-     "value": "Groups",
-     "title": "user groups"
-   }
+   "id": "ID",
+   "email": "Email",
+   "name": "Name",
+   "role": "Role",
+   "groups": "Groups"
  }
  """
 


### PR DESCRIPTION
:bread: 

/cc @zendesk/quokka

### Description
Make app template use the default i18n format as documented [here](https://developer.zendesk.com/apps/docs/agent/i18n).

### References
* HC community: https://support.zendesk.com/hc/en-us/community/posts/209137097-Whats-the-purpose-of-the-package-app-that-messes-with-translations- 

### Risks
* [low] Translations may not work for new apps created using ZAT