### PR TITLE
replace an unhandled crash with a handled crash

### DIFF
--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -13,9 +13,7 @@ module ZendeskAppsTools
 
       check_status response
 
-    rescue Faraday::Error::ClientError => e
-      say_error_and_exit e.message
-    rescue JSON::ParserError => e
+    rescue Faraday::Error::ClientError, JSON::ParserError => e
       say_error_and_exit e.message
     end
 
@@ -35,9 +33,7 @@ module ZendeskAppsTools
       response = connection.post('/api/v2/apps/uploads.json', payload)
       JSON.parse(response.body)['id']
 
-    rescue Faraday::Error::ClientError => e
-      say_error_and_exit e.message
-    rescue JSON::ParserError => e
+    rescue Faraday::Error::ClientError, JSON::ParserError => e
       say_error_and_exit e.message
     end
 

--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -8,7 +8,6 @@ module ZendeskAppsTools
       response = connection.send(connection_method) do |req|
         req.url url
         req.headers[:content_type] = 'application/json'
-
         req.body = JSON.generate body
       end
 
@@ -16,11 +15,13 @@ module ZendeskAppsTools
 
     rescue Faraday::Error::ClientError => e
       say_error_and_exit e.message
+    rescue JSON::ParserError => e
+      say_error_and_exit e.message
     end
 
     def upload(path)
       connection = get_connection :multipart
-      zipfile_path  = options[:zipfile]
+      zipfile_path = options[:zipfile]
 
       if zipfile_path
         package_path = zipfile_path


### PR DESCRIPTION
@zendesk/vegemite bring our handling of invalid json when polling the job status in line with the way we handle it everywhere else