### PR TITLE
bump faraday and multipart-post

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     zendesk_apps_tools (1.31.0)
-      faraday (~> 0.8.10)
+      faraday (~> 0.9.2)
       rubyzip (~> 0.9.1)
       sinatra (~> 1.4.6)
       thor (~> 0.18.1)
@@ -31,8 +31,8 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.6.0)
-    faraday (0.8.11)
-      multipart-post (~> 1.2.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.6)
     gherkin (2.12.2)
       multi_json (~> 1.3)
@@ -46,7 +46,7 @@ GEM
     json-stream (0.2.1)
     multi_json (1.11.2)
     multi_test (0.1.1)
-    multipart-post (1.2.0)
+    multipart-post (2.0.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'thor',        '~> 0.18.1'
   s.add_runtime_dependency 'rubyzip',     '~> 0.9.1'
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
-  s.add_runtime_dependency 'faraday',     '~> 0.8.10'
+  s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'zendesk_apps_support', '~> 1.28'
 
   s.add_development_dependency 'cucumber'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite @zendesk/wombat 

### Description

Just tested this with a `zat update`, seemed to work fine.

Removes these warnings:

```
/Users/me/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/multipart-post-1.2.0/lib/composite_io.rb:19: warning: UploadIO#respond_to?(:to_ary) is old fashion which takes only one parameter
/Users/me/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/multipart-post-1.2.0/lib/composite_io.rb:105: warning: respond_to? is defined here
```

### Risks
* [low] network calls do not behave as we expect