### PR TITLE
Satisfy preflight requests

### DIFF
--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -4,7 +4,6 @@ require 'zendesk_apps_support/package'
 module ZendeskAppsTools
   class Server < Sinatra::Base
     set :protection, :except => :frame_options
-    set :public_folder, proc { "#{settings.root}/assets" }
     last_mtime = Time.new(0)
     ZENDESK_DOMAINS_REGEX = /^http(?:s)?:\/\/[a-z0-9-]+\.(?:zendesk|zopim|zd-(?:dev|master|staging))\.com$/
 
@@ -42,6 +41,18 @@ module ZendeskAppsTools
       )
 
       ZendeskAppsSupport::Installed.new([app_js], [installation]).compile_js
+    end
+
+    get "/:file" do |file|
+      access_control_allow_origin
+      send_file File.join(settings.root, 'assets', file)
+    end
+
+    # This is for any preflight request
+    options "*" do
+      access_control_allow_origin
+      origin = request.env['HTTP_ORIGIN']
+      headers 'Access-Control-Allow-Headers' => request.env['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'] if origin =~ ZENDESK_DOMAINS_REGEX
     end
 
     def access_control_allow_origin

--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -49,12 +49,14 @@ module ZendeskAppsTools
     end
 
     # This is for any preflight request
+    # It reads 'Access-Control-Request-Headers' to set 'Access-Control-Allow-Headers'
+    # And also sets 'Access-Control-Allow-Origin' header
     options "*" do
-      #don't delete this
       access_control_allow_origin
       headers 'Access-Control-Allow-Headers' => request.env['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'] if request.env['HTTP_ORIGIN'] =~ ZENDESK_DOMAINS_REGEX
     end
 
+    # This sets the 'Access-Control-Allow-Origin' header for requests coming from zendesk
     def access_control_allow_origin
       origin = request.env['HTTP_ORIGIN']
       headers 'Access-Control-Allow-Origin' => origin if origin =~ ZENDESK_DOMAINS_REGEX

--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -50,9 +50,9 @@ module ZendeskAppsTools
 
     # This is for any preflight request
     options "*" do
+      #don't delete this
       access_control_allow_origin
-      origin = request.env['HTTP_ORIGIN']
-      headers 'Access-Control-Allow-Headers' => request.env['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'] if origin =~ ZENDESK_DOMAINS_REGEX
+      headers 'Access-Control-Allow-Headers' => request.env['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'] if request.env['HTTP_ORIGIN'] =~ ZENDESK_DOMAINS_REGEX
     end
 
     def access_control_allow_origin


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Browsers turn out to be draconian when it comes to getting anything else than an images or a javascript file.

Turns out 2 headers were added which makes this a CORS request with a preflight where we need to allow those headers

This PR satisfies all that, so i can load a .txt or .json file from my assets folder.

### References
* JIRA: 

### Risks