### PR TITLE
allow serving files from nested asset directories with CORS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       faraday (~> 0.9.2)
       rubyzip (~> 0.9.1)
       sinatra (~> 1.4.6)
+      sinatra-cross_origin (~> 0.3.1)
       thor (~> 0.18.1)
       zendesk_apps_support (~> 1.29)
 
@@ -30,7 +31,7 @@ GEM
       multi_test (>= 0.1.1)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    execjs (2.6.0)
+    execjs (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.6)
@@ -42,7 +43,7 @@ GEM
       execjs
       multi_json (>= 1.3)
       rake
-    json (1.8.3)
+    json (2.0.1)
     json-stream (0.2.1)
     multi_json (1.11.2)
     multi_test (0.1.1)
@@ -50,7 +51,7 @@ GEM
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
-    rake (11.1.2)
+    rake (11.2.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -71,12 +72,13 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    sinatra-cross_origin (0.3.2)
     thor (0.18.1)
-    tilt (2.0.2)
+    tilt (2.0.5)
     webmock (1.20.4)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-    zendesk_apps_support (1.29.2)
+    zendesk_apps_support (1.31.0)
       erubis
       i18n
       image_size
@@ -97,4 +99,4 @@ DEPENDENCIES
   zendesk_apps_tools!
 
 BUNDLED WITH
-   1.12.2
+   1.12.5

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -138,6 +138,7 @@ module ZendeskAppsTools
       ZendeskAppsTools::Server.tap do |server|
         server.set :port, options[:port]
         server.set :root, options[:path]
+        server.set :public_folder, File.join(options[:path], 'assets')
         server.set :parameters, settings
         server.set :manifest, manifest['parameters']
         server.set :config, options[:config]

--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -1,4 +1,5 @@
 require 'sinatra/base'
+require 'sinatra/cross_origin'
 require 'zendesk_apps_support/package'
 
 module ZendeskAppsTools
@@ -11,7 +12,7 @@ module ZendeskAppsTools
       access_control_allow_origin
       content_type 'text/javascript'
 
-      if File.exists? settings.config
+      if File.exist? settings.config
         curr_mtime = File.stat(settings.config).mtime
         if curr_mtime > last_mtime
           settings_helper = ZendeskAppsTools::Settings.new
@@ -43,10 +44,7 @@ module ZendeskAppsTools
       ZendeskAppsSupport::Installed.new([app_js], [installation]).compile_js
     end
 
-    get "/:file" do |file|
-      access_control_allow_origin
-      send_file File.join(settings.root, 'assets', file)
-    end
+    enable :cross_origin
 
     # This is for any preflight request
     # It reads 'Access-Control-Request-Headers' to set 'Access-Control-Allow-Headers'

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'zendesk_apps_support', '~> 1.29'
+  s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
 
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'aruba'


### PR DESCRIPTION
@zendesk/vegemite currently if you have a file like `assets/client/build/index.html` it will 404. Something to do with the `File.join`.

`public_folder` can't be set inside `server.rb` because that is run before we set the `path`.