### PR TITLE
explain the easiest solution for validation on windows

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -72,7 +72,15 @@ module ZendeskAppsTools
     method_options SHARED_OPTIONS
     def validate
       setup_path(options[:path])
-      errors = app_package.validate(marketplace: false)
+      begin
+        errors = app_package.validate(marketplace: false)
+      rescue ExecJS::RuntimeError
+        error = "There was an error trying to validate this app.\n"
+        if ExecJS.runtime.name == 'JScript'
+          error += 'To validate on Windows, please install node from https://nodejs.org/'
+        end
+        say_error_and_exit error
+      end
       valid = errors.none?
 
       if valid


### PR DESCRIPTION
`jshintrb` is not compatible with JScript, the JS runtime that ships with windows.
Installing node standalone is easier than any of the other [supported runtimes](https://github.com/rails/execjs/blob/master/lib/execjs/runtimes.rb#L82-L90) due to their compilation toolchains.
cc @zendesk/vegemite 