### PR TITLE
fix crash in zat server

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -13,9 +13,9 @@ module ZendeskAppsTools
     SHARED_OPTIONS = {
       ['path', '-p'] => './',
       clean: false
-    }
+    }.freeze
 
-    map %w[-v] => :version
+    map %w(-v) => :version
 
     source_root File.expand_path(File.join(File.dirname(__FILE__), '../..'))
 
@@ -136,7 +136,7 @@ module ZendeskAppsTools
       settings = settings_helper.get_settings_from_file options[:config], manifest.original_parameters
 
       unless settings
-        settings = settings_helper.get_settings_from_user_input self, manifest.original_parameters
+        settings = settings_helper.get_settings_from_user_input manifest.original_parameters
       end
 
       require 'zendesk_apps_tools/server'

--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -2,7 +2,6 @@ module ZendeskAppsTools
   module Deploy
     def deploy_app(connection_method, url, body)
       body[:upload_id] = upload(options[:path]).to_s
-
       connection = get_connection
 
       response = connection.send(connection_method) do |req|


### PR DESCRIPTION
modified this method to no longer need `self` passed in, it's saved in the constructor now.

cc @zendesk/vegemite 