### PR TITLE
fix dev environment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
       multi_json (>= 1.3)
       rake
     json (2.0.2)
+    json-stream (0.2.1)
     multi_json (1.12.1)
     multi_test (0.1.2)
     multipart-post (2.0.0)
@@ -92,6 +93,7 @@ GEM
       image_size
       jshintrb (~> 0.3.0)
       json
+      json-stream
       sass
 
 PLATFORMS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       sinatra (~> 1.4.6)
       sinatra-cross_origin (~> 0.3.1)
       thor (~> 0.19.1)
-      zendesk_apps_support (~> 3.1.0)
+      zendesk_apps_support (~> 3.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -52,7 +52,6 @@ GEM
       multi_json (>= 1.3)
       rake
     json (2.0.2)
-    json-stream (0.2.1)
     multi_json (1.12.1)
     multi_test (0.1.2)
     multipart-post (2.0.0)
@@ -87,13 +86,12 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    zendesk_apps_support (3.1.0)
+    zendesk_apps_support (3.1.1)
       erubis
       i18n
       image_size
       jshintrb (~> 0.3.0)
       json
-      json-stream
       sass
 
 PLATFORMS

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rubyzip',     '~> 1.2.0'
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 3.1.0'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 3.1.1'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
 
   s.add_development_dependency 'cucumber'


### PR DESCRIPTION
Oops, my local version of ZAS was built against https://github.com/zendesk/zendesk_apps_support/pull/131 now the Gemfile.lock is broken:

https://travis-ci.org/zendesk/zendesk_apps_tools/jobs/156989834

@zendesk/vegemite 

ZAS 3.1.0 depends on json-stream, 3.1.1 does not.