### PR TITLE
make v2 apps the default

### DIFF
--- a/features/new.feature
+++ b/features/new.feature
@@ -8,22 +8,23 @@ Feature: create a template for a new zendesk app
       | author email | john@example.com  |
       | author url   | http://myapp.com  |
       | app name     | John Test App     |
+      | iframe uri   | assets/iframe.html |
       | app dir      |                   |
 
    Then the app file "manifest.json" is created
    And I reset the working directory
 
-   Scenario: create a template for a new zendesk app by running 'zat new' command
-     Given an app directory "tmp/aruba" exists
-     When I run "zat new" command with the following details:
-       | author name  | John Citizen      |
-       | author email | john@example.com  |
-       | author url   | http://myapp.com  |
-       | app name     | John Test App     |
-       | app dir      | tmp/aruba         |
+  Scenario: create a template for a new zendesk app by running 'zat new --v1' command
+    Given an app directory "tmp/aruba" exists
+    When I run "zat new --v1" command with the following details:
+      | author name  | John Citizen      |
+      | author email | john@example.com  |
+      | author url   | http://myapp.com  |
+      | app name     | John Test App     |
+      | app dir      | tmp/aruba         |
 
-     Then the app file "tmp/aruba/manifest.json" is created with:
-     """
+    Then the app file "tmp/aruba/manifest.json" is created with:
+    """
  {
    "name": "John Test App",
    "author": {
@@ -37,9 +38,9 @@ Feature: create a template for a new zendesk app
    "version": "1.0",
    "frameworkVersion": "1.0"
  }
- """
-     And the app file "tmp/aruba/app.js" is created with:
-     """
+    """
+    And the app file "tmp/aruba/app.js" is created with:
+    """
  (function() {
 
    return {
@@ -52,9 +53,9 @@ Feature: create a template for a new zendesk app
    };
 
  }());
- """
-     And the app file "tmp/aruba/templates/layout.hdbs" is created with:
-     """
+    """
+    And the app file "tmp/aruba/templates/layout.hdbs" is created with:
+    """
  <header>
    <span class="logo"></span>
    <h3>{{setting "name"}}</h3>
@@ -65,9 +66,9 @@ Feature: create a template for a new zendesk app
      {{author.name}}
    </a>
  </footer>
- """
-     And the app file "tmp/aruba/translations/en.json" is created with:
-     """
+    """
+    And the app file "tmp/aruba/translations/en.json" is created with:
+    """
  {
    "app": {
      "description": "Play the famous zen tunes in your help desk.",
@@ -84,21 +85,21 @@ Feature: create a template for a new zendesk app
    "role": "Role",
    "groups": "Groups"
  }
- """
+    """
 
- Scenario: create a template for a new iframe only app by running 'zat new --v2' command
-   Given an app directory "tmp/aruba" exists
-   And I move to the app directory
-   When I run "zat new --v2" command with the following details:
-     | author name  | John Citizen      |
-     | author email | john@example.com  |
-     | author url   | http://myapp.com  |
-     | app name     | John Test App     |
-     | iframe uri   | assets/index.html |
-     | app dir      | tmp/aruba         |
+  Scenario: create a template for a new iframe only app by running 'zat new' command
+    Given an app directory "tmp/aruba" exists
+    And I move to the app directory
+    When I run "zat new" command with the following details:
+      | author name  | John Citizen      |
+      | author email | john@example.com  |
+      | author url   | http://myapp.com  |
+      | app name     | John Test App     |
+      | iframe uri   | assets/iframe.html |
+      | app dir      | tmp/aruba         |
 
-   Then the app file "tmp/aruba/manifest.json" is created with:
-   """
+    Then the app file "tmp/aruba/manifest.json" is created with:
+    """
 {
  "name": "John Test App",
  "author": {
@@ -109,10 +110,10 @@ Feature: create a template for a new zendesk app
  "defaultLocale": "en",
  "private": true,
  "location": { "zendesk":
-   { "ticket_sidebar": "assets/index.html" }
+   { "ticket_sidebar": "assets/iframe.html" }
  },
  "version": "1.0",
  "frameworkVersion": "2.0"
 }
-"""
+   """
    And I reset the working directory

--- a/features/package.feature
+++ b/features/package.feature
@@ -1,21 +1,33 @@
 Feature: package a zendesk app into a zip file
 
   Background: create a new zendesk app
-    Given an app is created in directory "tmp/aruba"
+
 
   Scenario: package a zendesk app by running 'zat package' command
+    Given an app is created in directory "tmp/aruba"
     When I run the command "zat package --path tmp/aruba" to package the app
-    And the command output should contain "adding app.js"
+    And the command output should contain "adding assets/iframe.html"
     And the command output should contain "adding assets/logo-small.png"
     And the command output should contain "adding assets/logo.png"
     And the command output should contain "adding manifest.json"
-    And the command output should contain "adding templates/layout.hdbs"
     And the command output should contain "adding translations/en.json"
     And the command output should contain "created"
     And the zip file should exist in directory "tmp/aruba/tmp"
 
+    Scenario: package a v1 zendesk app by running 'zat package' command
+      Given a v1 app is created in directory "tmp/aruba"
+      When I run the command "zat package --path tmp/aruba" to package the app
+      And the command output should contain "adding app.js"
+      And the command output should contain "adding templates/layout.hdbs"
+      And the command output should contain "adding assets/logo-small.png"
+      And the command output should contain "adding assets/logo.png"
+      And the command output should contain "adding manifest.json"
+      And the command output should contain "adding translations/en.json"
+      And the command output should contain "created"
+      And the zip file should exist in directory "tmp/aruba/tmp"
 
   Scenario: package a zendesk app by running 'zat package' command
+    Given an app is created in directory "tmp/aruba"
     When I create a symlink from "./templates/translation.erb.tt" to "tmp/aruba/assets/translation.erb.tt"
     Then "tmp/aruba/assets/translation.erb.tt" should be a symlink
     When I run the command "zat package --path tmp/aruba" to package the app

--- a/features/step_definitions/app_steps.rb
+++ b/features/step_definitions/app_steps.rb
@@ -17,14 +17,16 @@ Given /^an app directory "(.*?)" exists$/ do |app_dir|
   FileUtils.mkdir_p(@app_dir)
 end
 
-Given /^an app is created in directory "(.*?)"$/ do |app_dir|
+Given /^a(n|(?: v1)) app is created in directory "(.*?)"$/ do |version, app_dir|
+  v1 = !!version[/v1/]
   steps %(
     Given an app directory "#{app_dir}" exists
-    And I run "zat new" command with the following details:
+    And I run "zat new #{'--v1' if v1}" command with the following details:
       | author name  | John Citizen      |
       | author email | john@example.com  |
       | author url   | http://myapp.com  |
       | app name     | John Test App     |
+      #{'| iframe uri   | assets/iframe.html |' unless v1}
       | app dir      | #{app_dir}        |
     )
 end

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -28,9 +28,17 @@ module ZendeskAppsTools
     desc 'new', 'Generate a new app'
     method_option :'iframe-only', type: :boolean,
                                   default: false,
-                                  desc: 'Create an iFrame Only app template',
-                                  aliases: ['-i', '--v2']
+                                  hide: true,
+                                  aliases: ['--v2']
+    method_option :v1, type: :boolean, default: false, desc: 'Create a version 1 app template'
     def new
+      if options[:'iframe-only']
+        if options[:v1]
+          say_error_and_exit "Apps can't have both v1 and v2 set."
+        else
+          say_status 'warning', 'v2 is the default for new apps, the --v2 option has no effect.', :yellow
+        end
+      end
       enter = ->(variable) { "Enter this app author's #{variable}:\n" }
       invalid = ->(variable) { "Invalid #{variable}, try again:" }
       @author_name  = get_value_from_stdin(enter.call('name'),
@@ -45,18 +53,18 @@ module ZendeskAppsTools
       @app_name     = get_value_from_stdin("Enter a name for this new app:\n",
                                            error_msg: invalid.call('app name'))
 
-      @iframe_location = if options[:'iframe-only']
+      @iframe_location = if options[:v1]
+                           '_legacy'
+                         else
                            iframe_uri_text = 'Enter your iFrame URI or leave it blank to use'\
                                              " a default local template page:\n"
                            get_value_from_stdin(iframe_uri_text, allow_empty: true, default: 'assets/iframe.html')
-                         else
-                           '_legacy'
                          end
 
       prompt_new_app_dir
 
-      skeleton = options[:'iframe-only'] ? 'app_template_iframe' : 'app_template'
-      is_custom_iframe = options[:'iframe-only'] && @iframe_location != 'assets/iframe.html'
+      skeleton = options[:v1] ? 'app_template' : 'app_template_iframe'
+      is_custom_iframe = !options[:v1] && @iframe_location != 'assets/iframe.html'
       directory_options = is_custom_iframe ? { exclude_pattern: /iframe.html/ } : {}
       directory(skeleton, @app_dir, directory_options)
     end

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -32,13 +32,7 @@ module ZendeskAppsTools
                                   aliases: ['--v2']
     method_option :v1, type: :boolean, default: false, desc: 'Create a version 1 app template'
     def new
-      if options[:'iframe-only']
-        if options[:v1]
-          say_error_and_exit "Apps can't have both v1 and v2 set."
-        else
-          say_status 'warning', 'v2 is the default for new apps, the --v2 option has no effect.', :yellow
-        end
-      end
+      check_new_options
       enter = ->(variable) { "Enter this app author's #{variable}:\n" }
       invalid = ->(variable) { "Invalid #{variable}, try again:" }
       @author_name  = get_value_from_stdin(enter.call('name'),
@@ -193,6 +187,17 @@ module ZendeskAppsTools
     end
 
     protected
+
+    def check_new_options
+      if options[:'iframe-only']
+        if options[:v1]
+          say_error_and_exit "Apps can't be created with both --v1 and --v2 (or --iframe-only)."
+        else
+          warning = 'v2 is the default for new apps, the --v2 and --iframe-only options have no effect.'
+          say_status 'warning', warning, :yellow
+        end
+      end
+    end
 
     def setup_path(path)
       @destination_stack << relative_to_original_destination_root(path) unless @destination_stack.last == path


### PR DESCRIPTION
### Description

Makes the default output of `zat new` to be a v2 app.

@zendesk/vegemite 

### Screenshots

#### Passing a value that's already set by default

![screen shot 2016-10-06 at 3 56 56 pm](https://cloud.githubusercontent.com/assets/5535625/19141035/c39e9322-8bdd-11e6-8b17-90cdea69930d.png)

#### Trying to use both, you crazy javascript programmers

![screen shot 2016-10-06 at 3 57 06 pm](https://cloud.githubusercontent.com/assets/5535625/19141036/c3a07dfe-8bdd-11e6-9173-73c20ea979fd.png)

#### The new default in action

![screen shot 2016-10-06 at 3 57 31 pm](https://cloud.githubusercontent.com/assets/5535625/19141033/c39e074a-8bdd-11e6-8045-b3e8a16b5d09.png)

#### The v2 option doesn't show up any more even though we haven't deleted it

![screen shot 2016-10-06 at 3 57 58 pm](https://cloud.githubusercontent.com/assets/5535625/19141032/c39a8c6e-8bdd-11e6-9721-67cd91c6c938.png)

### References

come on @pmgrove what's the story?

### Risks

- [low] `zat new` doesn't work or surprises people