### PR TITLE
OFFAPPS-691 zat translate update --unattended

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -10,11 +10,6 @@ module ZendeskAppsTools
     include Thor::Actions
     include ZendeskAppsTools::CommandHelpers
 
-    SHARED_OPTIONS = {
-      ['path', '-p'] => './',
-      clean: false
-    }.freeze
-
     map %w(-v) => :version
 
     source_root File.expand_path(File.join(File.dirname(__FILE__), '../..'))
@@ -64,7 +59,7 @@ module ZendeskAppsTools
     end
 
     desc 'validate', 'Validate your app'
-    method_options SHARED_OPTIONS
+    shared_options(except: [:unattended])
     def validate
       setup_path(options[:path])
       begin
@@ -93,7 +88,7 @@ module ZendeskAppsTools
     end
 
     desc 'package', 'Package your app'
-    method_options SHARED_OPTIONS
+    shared_options(except: [:unattended])
     def package
       return false unless invoke(:validate, [])
 
@@ -154,7 +149,7 @@ module ZendeskAppsTools
     end
 
     desc 'create', 'Create app on your account'
-    method_options SHARED_OPTIONS
+    shared_options
     method_option :zipfile, default: nil, required: false, type: :string
     def create
       cache.clear
@@ -168,7 +163,7 @@ module ZendeskAppsTools
     end
 
     desc 'update', 'Update app on the server'
-    method_options SHARED_OPTIONS
+    shared_options
     method_option :zipfile, default: nil, required: false, type: :string
     def update
       cache.clear

--- a/lib/zendesk_apps_tools/command_helpers.rb
+++ b/lib/zendesk_apps_tools/command_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'zendesk_apps_tools/common'
 require 'zendesk_apps_tools/api_connection'
 require 'zendesk_apps_tools/deploy'

--- a/lib/zendesk_apps_tools/command_helpers.rb
+++ b/lib/zendesk_apps_tools/command_helpers.rb
@@ -14,6 +14,10 @@ module ZendeskAppsTools
     include ZendeskAppsTools::Directory
     include ZendeskAppsTools::PackageHelper
 
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
     def cache
       @cache ||= begin
         require 'zendesk_apps_tools/cache'

--- a/lib/zendesk_apps_tools/common.rb
+++ b/lib/zendesk_apps_tools/common.rb
@@ -1,5 +1,33 @@
+# frozen_string_literal: true
 module ZendeskAppsTools
   module Common
+    module ClassMethods
+      def shared_options(except: [])
+        unless except.include? :path
+          method_option :path,
+                        type: :string,
+                        default: './',
+                        aliases: ['-p']
+        end
+        unless except.include? :clean
+          method_option :clean,
+                        type: :boolean,
+                        default: false
+        end
+        unless except.include? :unattended
+          method_option :unattended,
+                        type: :boolean,
+                        default: false,
+                        desc: 'Experimental: Never prompt for input, expecting all input from the original invocation. Many '\
+                              'commands invoked with this option will just crash.'
+        end
+      end
+    end
+
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
     def say_error_and_exit(msg)
       say_error msg
       exit 1

--- a/lib/zendesk_apps_tools/common.rb
+++ b/lib/zendesk_apps_tools/common.rb
@@ -48,11 +48,8 @@ module ZendeskAppsTools
 
       while input = ask(prompt, thor_options)
         return '' if options[:allow_empty] && input.empty?
-        if input.to_s =~ options[:valid_regex]
-          break
-        else
-          say_error options[:error_msg]
-        end
+        break if input.to_s =~ options[:valid_regex]
+        say_error options[:error_msg]
       end
 
       input

--- a/lib/zendesk_apps_tools/common.rb
+++ b/lib/zendesk_apps_tools/common.rb
@@ -38,6 +38,7 @@ module ZendeskAppsTools
     end
 
     def get_value_from_stdin(prompt, opts = {})
+      error_if_unattended(prompt)
       options = {
         valid_regex: opts[:allow_empty] ? /^.*$/ : /\S+/,
         error_msg: 'Invalid, try again:',
@@ -56,9 +57,18 @@ module ZendeskAppsTools
     end
 
     def get_password_from_stdin(prompt)
+      error_if_unattended(prompt)
       password = ask(prompt, echo: false)
       say ''
       password
+    end
+
+    private
+
+    def error_if_unattended(prompt)
+      return unless options[:unattended]
+      say_error 'Would have prompted for a value interactively, but we are running unattended.'
+      say_error_and_exit prompt
     end
   end
 end

--- a/lib/zendesk_apps_tools/translate.rb
+++ b/lib/zendesk_apps_tools/translate.rb
@@ -93,7 +93,7 @@ module ZendeskAppsTools
       end
 
       def write_json(filename, translations_hash)
-        create_file(filename, JSON.pretty_generate(translations_hash) + "\n")
+        create_file(filename, JSON.pretty_generate(translations_hash) + "\n", force: options[:unattended])
       end
 
       def nest_translations_hash(translations_hash, key_prefix)

--- a/lib/zendesk_apps_tools/translate.rb
+++ b/lib/zendesk_apps_tools/translate.rb
@@ -12,7 +12,7 @@ module ZendeskAppsTools
     LOCALE_ENDPOINT = 'https://support.zendesk.com/api/v2/locales/agent.json'
 
     desc 'to_yml', 'Create Zendesk translation file from en.json'
-    method_option :path, default: './', required: false
+    shared_options(except: [:clean])
     def to_yml
       setup_path(options[:path]) if options[:path]
       manifest = JSON.parse(File.open("#{destination_root}/manifest.json").read)
@@ -32,7 +32,7 @@ module ZendeskAppsTools
     end
 
     desc 'to_json', 'Convert Zendesk translation yml to I18n formatted json'
-    method_option :path, default: './', required: false
+    shared_options(except: [:clean])
     def to_json
       require 'yaml'
       setup_path(options[:path]) if options[:path]
@@ -46,8 +46,9 @@ module ZendeskAppsTools
     end
 
     desc 'update', 'Update translation files from Zendesk'
-    method_option :path, default: './', required: false
-    def update()
+    shared_options(except: [:clean])
+    method_option :package_name, type: :string
+    def update
       setup_path(options[:path]) if options[:path]
       app_package = get_value_from_stdin('What is the package name for this app? (without app_)', valid_regex: /^[a-z_]+$/, error_msg: 'Invalid package name, try again:')
 
@@ -77,7 +78,7 @@ module ZendeskAppsTools
     end
 
     desc 'pseudotranslate', 'Generate a Pseudo-translation to use for testing. This will pretend to be French.'
-    method_option :path, default: './', required: false
+    shared_options(except: [:clean])
     def pseudotranslate
       setup_path(options[:path]) if options[:path]
 

--- a/spec/lib/zendesk_apps_tools/common_spec.rb
+++ b/spec/lib/zendesk_apps_tools/common_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'zendesk_apps_tools/common'
+
+describe ZendeskAppsTools::Common do
+  let(:subject_class) do
+    Class.new do
+      include ZendeskAppsTools::Common
+      def options
+        {}
+      end
+
+      def say(message, color = nil)
+      end
+
+      def ask(prompt, options)
+      end
+    end
+  end
+  let(:subject) do
+    subject_class.new
+  end
+
+  describe '#get_value_from_stdin' do
+    it 'errors if unattended' do
+      allow(subject).to receive(:options).and_return(unattended: true)
+      expect { subject.get_value_from_stdin('prompt') }.to raise_error(SystemExit)
+    end
+
+    it 'returns the asked value' do
+      allow(subject).to receive(:ask).and_return('test value')
+      expect(subject.get_value_from_stdin('prompt')).to eq 'test value'
+    end
+  end
+
+  describe '#get_password_from_stdin' do
+    it 'errors if unattended' do
+      allow(subject).to receive(:options).and_return(unattended: true)
+      expect { subject.get_password_from_stdin('prompt') }.to raise_error(SystemExit)
+    end
+
+    it 'returns the asked value' do
+      allow(subject).to receive(:ask).and_return('test value')
+      expect(subject.get_password_from_stdin('prompt')).to eq 'test value'
+    end
+
+    it 'does not echo' do
+      expect(subject).to receive(:ask).with('prompt', hash_including(echo: false))
+      subject.get_password_from_stdin('prompt')
+    end
+  end
+
+  describe '#say_error' do
+    it 'outputs a red message' do
+      expect(subject).to receive(:say).with('goodbye world', :red)
+      subject.say_error 'goodbye world'
+    end
+  end
+
+  describe '#say_error_and_exit' do
+    it 'calls say_error and quits' do
+      expect(subject).to receive(:say).with('goodbye world', :red)
+      expect { subject.say_error_and_exit 'goodbye world' }.to raise_error(SystemExit)
+    end
+  end
+
+  describe '.shared_options' do
+    it 'calls method_option three times' do
+      expect(subject.class).to receive(:method_option).exactly(3).times
+      subject.class.shared_options
+    end
+
+    it 'respects `except`' do
+      expect(subject.class).to receive(:method_option).exactly(2).times
+      subject.class.shared_options(except: [:clean])
+    end
+  end
+end

--- a/spec/lib/zendesk_apps_tools/settings_spec.rb
+++ b/spec/lib/zendesk_apps_tools/settings_spec.rb
@@ -5,12 +5,13 @@ require 'settings'
 describe ZendeskAppsTools::Settings do
   before(:each) do
     @user_input = Object.new
-    @user_input.extend(ZendeskAppsTools::Common)
-    @context = ZendeskAppsTools::Settings.new(@user_input)
     allow(@user_input).to receive(:ask) do |_p, thor_opts| # this represents the default user input
       thor_opts && thor_opts[:default] || ''
     end
     allow(@user_input).to receive(:say)
+    allow(@user_input).to receive(:options).and_return({})
+    @user_input.extend(ZendeskAppsTools::Common)
+    @context = ZendeskAppsTools::Settings.new(@user_input)
   end
 
   describe '#get_settings_from_user_input' do

--- a/spec/lib/zendesk_apps_tools/translate_spec.rb
+++ b/spec/lib/zendesk_apps_tools/translate_spec.rb
@@ -85,7 +85,7 @@ describe ZendeskAppsTools::Translate do
     it 'fetches locales, translations and generates json files for each' do
       translate = ZendeskAppsTools::Translate.new
       allow(translate).to receive(:say)
-      allow(translate).to receive(:ask).with('What is the package name for this app? (without app_)', default: nil).and_return('my_app')
+      allow(translate).to receive(:ask).with('What is the package name for this app? (without leading app_)', default: nil).and_return('my_app')
       allow(translate).to receive(:create_file)
 
       expect(translate).to receive(:nest_translations_hash).once.and_return({})


### PR DESCRIPTION
### Description

- Refactor the way we do shared_options because thor's `method_options` doesn't provide as much niceness as `method_option`.
- Implement a `--unattended` option for some commands so that nobody is ever left with a stuck prompt waiting for input.
- Refactor of `zat translate SUBCOMMAND` especially `zat translate update` to be more consistent with linter rules and to `exit 1` instead of `exit 0` on error

cc @zendesk/vegemite @zendesk/wombat 

### References

https://zendesk.atlassian.net/browse/OFFAPPS-691

### Risks

- [low] since this affects options across many commands, many of them might crash / not work