### PR TITLE
Adding support for binding using zat server

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -123,6 +123,7 @@ module ZendeskAppsTools
     method_option :config, default: DEFAULT_CONFIG_PATH, required: false, aliases: '-c'
     method_option :port, default: DEFAULT_SERVER_PORT, required: false
     method_option :app_id, default: DEFAULT_APP_ID, required: false
+    method_option :bind, default: "127.0.0.1", required: false
     def server
       setup_path(options[:path])
       manifest = app_package.manifest
@@ -139,6 +140,7 @@ module ZendeskAppsTools
       require 'zendesk_apps_tools/server'
       ZendeskAppsTools::Server.tap do |server|
         server.set :settings_helper, settings_helper
+        server.set :bind, options[:bind]
         server.set :port, options[:port]
         server.set :root, options[:path]
         server.set :public_folder, File.join(options[:path], 'assets')


### PR DESCRIPTION
Adding support to allow binding a specific ip address when using zat server. This would be useful for our case when developing using a vagrant/virtual machine, as we tend to bind our tools to 0.0.0.0 when testing and setup our virtual machine to allow access to the virtual machine through a specific ip/host.