### PR TITLE
handle false values in settings files if there is also a default

### DIFF
--- a/lib/zendesk_apps_tools/settings.rb
+++ b/lib/zendesk_apps_tools/settings.rb
@@ -53,7 +53,7 @@ module ZendeskAppsTools
       end
 
       parameters.each_with_object({}) do |param, settings|
-        input = settings_data[param['name']] || param['default']
+        input = settings_data.fetch(param['name'], param['default'])
 
         if !input && param['required']
           @cli.say_error "'#{param['name']}' is required but not specified in the config file.\n"

--- a/spec/fixture/config/settings.yml
+++ b/spec/fixture/config/settings.yml
@@ -5,3 +5,4 @@ array:
     - test1
 object:
     test1: value
+falsey: false

--- a/spec/lib/zendesk_apps_tools/settings_spec.rb
+++ b/spec/lib/zendesk_apps_tools/settings_spec.rb
@@ -165,7 +165,7 @@ describe ZendeskAppsTools::Settings do
         expect(@context.get_settings_from_file('spec/fixture/config/settings.yml', parameters)).to eq(settings)
       end
 
-      it 'returns the default because you forgot to specifiy a required field with a default' do
+      it 'returns the default because you forgot to specify a required field with a default' do
         parameters = [
           {
             'name' => 'required',
@@ -192,6 +192,18 @@ describe ZendeskAppsTools::Settings do
         ]
 
         expect(@context.get_settings_from_file('spec/fixture/config/settings.yml', parameters)).to be_nil
+      end
+
+      it 'returns false if specified even if the default is true' do
+        parameters = [
+          {
+            'name' => 'falsey',
+            'type' => 'checkbox',
+            'default' => true
+          }
+        ]
+
+        expect(@context.get_settings_from_file('spec/fixture/config/settings.yml', parameters)).to eq 'falsey' => false
       end
     end
   end


### PR DESCRIPTION
### Description

Fixes a bug where falsey values in `settings.yml` or `settings.json` get overridden by the default for that setting.

### References
- https://zendesk-appdevelopers.slack.com/archives/apps-framework/p1478420251000091
- https://gist.github.com/joelhellman/b30c9edc094f3cc3f371c4c584a890c8