### PR TITLE
show a useful error when there is no JS runtime at all

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -66,7 +66,9 @@ module ZendeskAppsTools
         errors = app_package.validate(marketplace: false)
       rescue ExecJS::RuntimeError
         error = "There was an error trying to validate this app.\n"
-        if ExecJS.runtime.name == 'JScript'
+        if ExecJS.runtime.nil?
+          error += 'Validation relies on a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes.'
+        elsif ExecJS.runtime.name == 'JScript'
           error += 'To validate on Windows, please install node from https://nodejs.org/'
         end
         say_error_and_exit error


### PR DESCRIPTION
https://support.zendesk.com/hc/en-us/community/posts/235344447

cc @zendesk/vegemite 