### PR TITLE
support --unattended in zat server, read default parameters instead of crashing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: ruby
 rvm:
   - 2.0
   - 2.1
-  - 2.2.5
-  - 2.3.1
+  - 2.2.6
+  - 2.3.3
 branches:
   only:
     - master

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -125,7 +125,7 @@ module ZendeskAppsTools
     method_option :config, default: DEFAULT_CONFIG_PATH, required: false, aliases: '-c'
     method_option :port, default: DEFAULT_SERVER_PORT, required: false
     method_option :app_id, default: DEFAULT_APP_ID, required: false
-    method_option :bind, default: "127.0.0.1", required: false
+    method_option :bind, required: false
     def server
       setup_path(options[:path])
       manifest = app_package.manifest
@@ -142,7 +142,7 @@ module ZendeskAppsTools
       require 'zendesk_apps_tools/server'
       ZendeskAppsTools::Server.tap do |server|
         server.set :settings_helper, settings_helper
-        server.set :bind, options[:bind]
+        server.set :bind, options[:bind] if options[:bind]
         server.set :port, options[:port]
         server.set :root, options[:path]
         server.set :public_folder, File.join(options[:path], 'assets')

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -121,7 +121,7 @@ module ZendeskAppsTools
     DEFAULT_APP_ID = 0
 
     desc 'server', 'Run a http server to serve the local app'
-    method_option :path, default: DEFAULT_SERVER_PATH, required: false, aliases: '-p'
+    shared_options(except: [:clean])
     method_option :config, default: DEFAULT_CONFIG_PATH, required: false, aliases: '-c'
     method_option :port, default: DEFAULT_SERVER_PORT, required: false
     method_option :app_id, default: DEFAULT_APP_ID, required: false

--- a/lib/zendesk_apps_tools/common.rb
+++ b/lib/zendesk_apps_tools/common.rb
@@ -76,7 +76,7 @@ module ZendeskAppsTools
 
     def error_or_default_if_unattended(prompt, opts = {})
       if options[:unattended]
-        return opts[:default] if opts[:default]
+        return opts[:default] if opts.key? :default
         say_error 'Would have prompted for a value interactively, but zat is not listening to keyboard input.'
         say_error_and_exit prompt
       else

--- a/lib/zendesk_apps_tools/common.rb
+++ b/lib/zendesk_apps_tools/common.rb
@@ -58,7 +58,7 @@ module ZendeskAppsTools
     end
 
     def get_password_from_stdin(prompt)
-      error_or_default_if_unattended(prompt, opts) do
+      error_or_default_if_unattended(prompt) do
         password = ask(prompt, echo: false)
         say ''
         password
@@ -74,7 +74,7 @@ module ZendeskAppsTools
 
     private
 
-    def error_or_default_if_unattended(prompt, opts)
+    def error_or_default_if_unattended(prompt, opts = {})
       if options[:unattended]
         return opts[:default] if opts[:default]
         say_error 'Would have prompted for a value interactively, but zat is not listening to keyboard input.'

--- a/lib/zendesk_apps_tools/settings.rb
+++ b/lib/zendesk_apps_tools/settings.rb
@@ -10,7 +10,7 @@ module ZendeskAppsTools
       return {} if parameters.nil?
 
       parameters.inject({}) do |settings, param|
-        if param['default']
+        if param.key? 'default'
           input = @cli.get_value_from_stdin("Enter a value for parameter '#{param['name']}':\n", default: param['default'])
         elsif param['required']
           input = @cli.get_value_from_stdin("Enter a value for required parameter '#{param['name']}':\n")


### PR DESCRIPTION
I think it's better to do this because foreman in the app scaffold will dump a bunch of webpack output after asking for a setting, this caused confusion.

cc @zendesk/vegemite 