### PR TITLE
fix load path on ruby 2.3.3, fix warning

### DIFF
--- a/bin/zat
+++ b/bin/zat
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 lib_dir = File.expand_path('../../lib', __FILE__)
-$LOAD_PATH.shift lib_dir unless $LOAD_PATH.include?(lib_dir)
+$LOAD_PATH.unshift lib_dir unless $LOAD_PATH.include?(lib_dir)
 ENV['THOR_SHELL'] = 'Color'
 require 'zendesk_apps_tools'
 ZendeskAppsTools::Command.start

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -120,8 +120,8 @@ module ZendeskAppsTools
 
     DEFAULT_SERVER_PATH = './'
     DEFAULT_CONFIG_PATH = './settings.yml'
-    DEFAULT_SERVER_PORT = 4567
-    DEFAULT_APP_ID = 0
+    DEFAULT_SERVER_PORT = '4567'
+    DEFAULT_APP_ID = '0'
 
     desc 'server', 'Run a http server to serve the local app'
     shared_options(except: [:clean])


### PR DESCRIPTION
### Description

Fixes a crash:

```
/Users/rsandler/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/zendesk_apps_tools-1.35.11/bin/zat:3:in `shift': no implicit conversion of String into Integer (TypeError)
	from /Users/rsandler/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/zendesk_apps_tools-1.35.11/bin/zat:3:in `<top (required)>'
	from /Users/rsandler/.rbenv/versions/2.3.3/bin/zat:22:in `load'
	from /Users/rsandler/.rbenv/versions/2.3.3/bin/zat:22:in `<main>'
```

and a warning:

```
Expected string default value for '--port'; got 4567 (numeric)
Expected string default value for '--app-id'; got 0 (numeric)
```

cc @zendesk/vegemite 

### References

https://support.zendesk.com/agent/tickets/2051273

### Risks

- [low] zat still not working on ruby 2.3.3