### PR TITLE
Fix write directory for translations

### DIFF
--- a/lib/zendesk_apps_tools/translate.rb
+++ b/lib/zendesk_apps_tools/translate.rb
@@ -57,7 +57,7 @@ module ZendeskAppsTools
 
           locale_name = ZendeskAppsTools::LocaleIdentifier.new(locale['locale']).locale_id
           write_json(
-            "#{destination_root}/translations/#{locale_name}.json",
+            "translations/#{locale_name}.json",
             nest_translations_hash(translations, "txt.apps.#{app_package}.")
           )
         end

--- a/spec/lib/zendesk_apps_tools/translate_spec.rb
+++ b/spec/lib/zendesk_apps_tools/translate_spec.rb
@@ -89,6 +89,7 @@ describe ZendeskAppsTools::Translate do
       allow(translate).to receive(:create_file)
 
       expect(translate).to receive(:nest_translations_hash).once.and_return({})
+      expect(translate).to receive(:write_json).once.with("translations/en.json", {})
 
       stub_request(:get, "https://support.zendesk.com/api/v2/locales/agent.json").
          to_return(:status => 200, :body => JSON.dump('locales' => [{ 'url' => 'https://support.zendesk.com/api/v2/rosetta/locales/1.json', 'locale' => 'en' }]))


### PR DESCRIPTION
/cc @zendesk/undefined

### Description
When specifying an optional path flag, prevent the root directory name being recreated and nested i.e. stop stuff like `/dist/dist/translations/` happening


### References
* JIRA: AF-564

### Risks