### PR TITLE
Include zendesk garden in iframe template

### DIFF
--- a/app_template_iframe/assets/iframe.html
+++ b/app_template_iframe/assets/iframe.html
@@ -1,13 +1,18 @@
 <html>
+<head>
+  <meta charset="utf-8">
+  <!-- http://garden.zendesk.com -->
+  <link rel="stylesheet" href="https://assets.zendesk.com/apps/sdk-assets/css/0/zendesk_garden.css" type="text/css">
+</head>
 <body>
-  <h2>Zendesk Apps Tools Iframe Scaffold</h2>
+  <h2 class="u-gamma">Hello, World!</h2>
   <!-- https://github.com/zendesk/zendesk_app_framework_sdk -->
   <script type="text/javascript" src="https://assets.zendesk.com/apps/sdk/2.0/zaf_sdk.js"></script>
   <script>
     // Initialise the Zendesk JavaScript API client
     // https://developer.zendesk.com/apps/docs/apps-v2
     var client = ZAFClient.init();
-    client.invoke('resize', { width: '100%', height: '400px' });
+    client.invoke('resize', { width: '100%', height: '200px' });
   </script>
 </body>
 </html>


### PR DESCRIPTION
#:v:

/cc @zendesk/vegemite

### Description

Include zendesk garden in iframe template for all new v2 apps created with zat.

### Screenshot
![screen shot 2017-01-04 at 3 51 33 pm](https://cloud.githubusercontent.com/assets/153219/21632005/cbbf293c-d295-11e6-9bbe-155a7d703db1.png)

### Risks
* [low] include base stylesheet in new apps, no more ugly default fonts