### PR TITLE
Bump ZAS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       sinatra (~> 1.4.6)
       sinatra-cross_origin (~> 0.3.1)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 3.3.3)
+      zendesk_apps_support (~> 3.3.5)
 
 GEM
   remote: https://rubygems.org/
@@ -77,7 +77,7 @@ GEM
     rubyzip (1.2.0)
     safe_yaml (1.0.4)
     sass (3.4.23)
-    sassc (1.11.0)
+    sassc (1.11.1)
       bundler
       ffi (~> 1.9.6)
       sass (>= 3.3.0)
@@ -92,7 +92,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    zendesk_apps_support (3.3.3)
+    zendesk_apps_support (3.3.5)
       erubis
       i18n
       image_size

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rubyzip',     '~> 1.2.0'
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 3.3.3'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 3.3.5'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
 
   s.add_development_dependency 'cucumber'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description

Planning to release a new version after this gets merged.

https://github.com/zendesk/zendesk_apps_support/compare/v3.3.3...v3.3.5

### Risks
* low: some apps specifying v2-only locations in a v1 app will not validate
* low: marketing only apps will not validate if they are missing `private: false`