### PR TITLE
Make app_id default to a numeric value instead of a string

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -121,13 +121,13 @@ module ZendeskAppsTools
     DEFAULT_SERVER_PATH = './'
     DEFAULT_CONFIG_PATH = './settings.yml'
     DEFAULT_SERVER_PORT = '4567'
-    DEFAULT_APP_ID = '0'
+    DEFAULT_APP_ID = 0
 
     desc 'server', 'Run a http server to serve the local app'
     shared_options(except: [:clean])
     method_option :config, default: DEFAULT_CONFIG_PATH, required: false, aliases: '-c'
     method_option :port, default: DEFAULT_SERVER_PORT, required: false
-    method_option :app_id, default: DEFAULT_APP_ID, required: false
+    method_option :app_id, default: DEFAULT_APP_ID, required: false, type: :numeric
     method_option :bind, required: false
     def server
       setup_path(options[:path])


### PR DESCRIPTION
@zendesk/vegemite 

Hey guys, if we have a line in an app like the [following](https://github.com/zendesk/timetracking_app/blob/master/app.js#L66):

```onAppCreated: function() {
  if (this.installationId()) {
    ... blah blah here
  }
```

if you are running the app from zat (which I think this conditional is checking for), the installationId() method was returning a string '0' by default, which is truthy. I've changed ZAT to only use a default app_id of the numeric 0 where necessary. I suppose I could just do `parseInt(this.installationId(), 10)` instead, but I wanted to see why this was happening at the source.

I took a look at Thor's [Method Options](https://github.com/erikhuda/thor/wiki/Method-Options) docs as a reference for forcing a numeric type.

Thoughts?




