### PR TITLE
warn and set to UTF-8 as early as possible

### DIFF
--- a/bin/zat
+++ b/bin/zat
@@ -1,4 +1,11 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+default_ext = Encoding.default_external
+unless default_ext == Encoding::UTF_8
+  Encoding.default_external = Encoding::UTF_8
+  puts "Warning: unexpected string encoding: #{default_ext}, zat runs best in UTF-8."
+  puts 'Please set the RUBYOPT environment variable to "-E utf-8".'
+end
 lib_dir = File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift lib_dir unless $LOAD_PATH.include?(lib_dir)
 ENV['THOR_SHELL'] = 'Color'


### PR DESCRIPTION
### Description

Point people in the right direction to avoid encoding dramas.
Hard to give more specific instructions though - they depend on the platform, shell and how long-lived they want the change to be.
We shouldn't set this variable on a user's behalf either, both because it may clobber an encoding they intentionally and it may overwrite other settings in `RUBYOPT`.

cc @zendesk/vegemite

### References

https://support.zendesk.com/hc/en-us/community/posts/203461336-Problems-with-accents-in-templates-

### Risks

- [medium] zat stops working on certain windows versions if they don't support UTF-8.