### PR TITLE
Set install_id from ZAT

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -153,7 +153,7 @@ module ZendeskAppsTools
         server.set :public_folder, File.join(options[:path], 'assets')
         server.set :parameters, settings
         server.set :app_id, options[:app_id]
-        server.set :install_id, options[:install_id]
+        server.set :install_id, options[:install_id] || options[:app_id] # backwards compatible
         server.run!
       end
     end

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -153,7 +153,7 @@ module ZendeskAppsTools
         server.set :public_folder, File.join(options[:path], 'assets')
         server.set :parameters, settings
         server.set :app_id, options[:app_id]
-        server.set :install_id, options[:install_id] || options[:app_id] # backwards compatible
+        server.set :install_id, options[:install_id] != 0 ? options[:install_id] : options[:app_id] # backwards compatible
         server.run!
       end
     end

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -153,7 +153,7 @@ module ZendeskAppsTools
         server.set :public_folder, File.join(options[:path], 'assets')
         server.set :parameters, settings
         server.set :app_id, options[:app_id]
-        server.set :install_id, options[:install_id] != 0 ? options[:install_id] : options[:app_id] # backwards compatible
+        server.set :install_id, options[:install_id] != DEFAULT_INSTALL_ID ? options[:install_id] : options[:app_id] # backwards compatible
         server.run!
       end
     end

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -122,12 +122,14 @@ module ZendeskAppsTools
     DEFAULT_CONFIG_PATH = './settings.yml'
     DEFAULT_SERVER_PORT = '4567'
     DEFAULT_APP_ID = 0
+    DEFAULT_INSTALL_ID = 0
 
     desc 'server', 'Run a http server to serve the local app'
     shared_options(except: [:clean])
     method_option :config, default: DEFAULT_CONFIG_PATH, required: false, aliases: '-c'
     method_option :port, default: DEFAULT_SERVER_PORT, required: false
     method_option :app_id, default: DEFAULT_APP_ID, required: false, type: :numeric
+    method_option :install_id, default: DEFAULT_INSTALL_ID, required: false, type: :numeric
     method_option :bind, required: false
     def server
       setup_path(options[:path])
@@ -151,6 +153,7 @@ module ZendeskAppsTools
         server.set :public_folder, File.join(options[:path], 'assets')
         server.set :parameters, settings
         server.set :app_id, options[:app_id]
+        server.set :install_id, options[:install_id]
         server.run!
       end
     end

--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -17,7 +17,7 @@ module ZendeskAppsTools
       package = ZendeskAppsSupport::Package.new(settings.root, false)
       app_name = package.manifest.name || 'Local App'
       installation = ZendeskAppsSupport::Installation.new(
-        id: settings.app_id,
+        id: settings.install_id,
         app_id: settings.app_id,
         app_name: app_name,
         enabled: true,


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
You can set the app id, but not the install id. This PR allows you to set the install id. Useful for using the proxy and testing currently installed apps locally.

### References
* JIRA: 

### Risks
- [low] technically when using app_id it doesn't set install_id anymore.