### PR TITLE
Bump rubyzip

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     zendesk_apps_tools (1.37.4)
       faraday (~> 0.9.2)
-      rubyzip (~> 1.2.0)
+      rubyzip (~> 1.2.1)
       sinatra (~> 1.4.6)
       sinatra-cross_origin (~> 0.3.1)
       thor (~> 0.19.4)
@@ -74,7 +74,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubyzip (1.2.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.4.23)
     sassc (1.11.2)

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
 
   s.add_runtime_dependency 'thor',        '~> 0.19.4'
-  s.add_runtime_dependency 'rubyzip',     '~> 1.2.0'
+  s.add_runtime_dependency 'rubyzip',     '~> 1.2.1'
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'zendesk_apps_support', '~> 3.3.5'


### PR DESCRIPTION
@zendesk/sustaining 

rubyzip ( < 1.2.1 ) is vulnerable to directory traversals. A malicious user can prepend ../ to the file’s directory path to traverse the directory to create and overwrite arbitrary files.

Ref: https://support.zendesk.com/agent/tickets/2316100