### PR TITLE
fix code that detects whether translation files have changed or not

### DIFF
--- a/lib/zendesk_apps_tools/translate.rb
+++ b/lib/zendesk_apps_tools/translate.rb
@@ -93,7 +93,7 @@ module ZendeskAppsTools
       end
 
       def write_json(filename, translations_hash)
-        create_file(filename, JSON.pretty_generate(translations_hash) + "\n", force: options[:unattended])
+        create_file(filename, JSON.pretty_generate(translations_hash).force_encoding('ASCII-8BIT') + "\n", force: options[:unattended])
       end
 
       def nest_translations_hash(translations_hash, key_prefix)


### PR DESCRIPTION
### Description

Currently when we do `zat translate update --unattended` we see output like this when nothing has changed:

```
       force  translations/ar.json
       force  translations/pt-br.json
   identical  translations/en-gb.json
       force  translations/bg.json
   identical  translations/en-ca.json
       force  translations/fr-ca.json
       force  translations/cs.json
       force  translations/da.json
   identical  translations/nl.json
   identical  translations/en-US.json
       force  translations/es-es.json
       force  translations/fi.json
       force  translations/fr.json
       force  translations/de.json
       force  translations/it.json
       force  translations/ja.json
       force  translations/ko.json
       force  translations/es-419.json
       force  translations/no.json
       force  translations/pl.json
       force  translations/pt.json
       force  translations/ro.json
       force  translations/ru.json
       force  translations/zh-cn.json
       force  translations/es.json
       force  translations/sv.json
       force  translations/zh-tw.json
       force  translations/tr.json
   identical  translations/uk.json
```

with this PR, we'll instead see

```
   identical  translations/ar.json
   identical  translations/pt-br.json
   identical  translations/en-gb.json
   identical  translations/bg.json
   identical  translations/en-ca.json
   identical  translations/fr-ca.json
   identical  translations/cs.json
   identical  translations/da.json
   identical  translations/nl.json
   identical  translations/en-US.json
   identical  translations/es-es.json
   identical  translations/fi.json
   identical  translations/fr.json
   identical  translations/de.json
   identical  translations/it.json
   identical  translations/ja.json
   identical  translations/ko.json
   identical  translations/es-419.json
   identical  translations/no.json
   identical  translations/pl.json
   identical  translations/pt.json
   identical  translations/ro.json
   identical  translations/ru.json
   identical  translations/zh-cn.json
   identical  translations/es.json
   identical  translations/sv.json
   identical  translations/zh-tw.json
   identical  translations/tr.json
   identical  translations/uk.json
```

cc @zendesk/vegemite 

This is caused by us using the [thor](https://github.com/erikhuda/thor/blob/master/lib/thor/actions/create_file.rb) library `create_file` function. Thor does a [`binread`](https://ruby-doc.org/core-2.1.0/IO.html#method-c-binread) on the existing translation file, which always reads it in as ASCII-8BIT encoding, but the value we fetch from the API is UTF-8. For purposes of comparison, we need to change the encoding on the API value to match the encoding we see on the local file.

### Risks

- [low] translations with non-ascii characters don't look right