### PR TITLE
install after zat create

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -145,7 +145,7 @@ module ZendeskAppsTools
       end
     end
 
-    desc 'create', 'Create app on your account'
+    desc 'create', 'Create and install app on your account'
     shared_options
     method_option :zipfile, default: nil, required: false, type: :string
     method_option :config, default: DEFAULT_CONFIG_PATH, required: false, aliases: '-c'

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -148,12 +148,13 @@ module ZendeskAppsTools
     desc 'create', 'Create app on your account'
     shared_options
     method_option :zipfile, default: nil, required: false, type: :string
+    method_option :config, default: DEFAULT_CONFIG_PATH, required: false, aliases: '-c'
     def create
       cache.clear
       @command = 'Create'
 
       unless options[:zipfile]
-        app_name = JSON.parse(File.read(File.join options[:path], 'manifest.json'))['name']
+        app_name = manifest.name
       end
       app_name ||= get_value_from_stdin('Enter app name:')
       deploy_app(:post, '/api/v2/apps.json', name: app_name)

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -149,6 +149,7 @@ module ZendeskAppsTools
     shared_options
     method_option :zipfile, default: nil, required: false, type: :string
     method_option :config, default: DEFAULT_CONFIG_PATH, required: false, aliases: '-c'
+    method_option :install, default: true, type: :boolean, desc: 'Also create an installation with some settings immediately after uploading.'
     def create
       cache.clear
       @command = 'Create'
@@ -159,6 +160,7 @@ module ZendeskAppsTools
       app_name ||= get_value_from_stdin('Enter app name:')
       deploy_app(:post, '/api/v2/apps.json', name: app_name)
       has_requirements = File.exist?(File.join(options[:path], 'requirements.json'))
+      return unless options[:install]
       say_status 'Install', 'installing'
       install_app(has_requirements, app_id: cache.fetch('app_id'), settings: settings.merge(name: app_name))
     end

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -161,7 +161,6 @@ module ZendeskAppsTools
       has_requirements = File.exist?(File.join(options[:path], 'requirements.json'))
       say_status 'Install', 'installing'
       install_app(has_requirements, app_id: cache.fetch('app_id'), settings: settings.merge(name: app_name))
-      say_status 'Install', 'OK'
     end
 
     desc 'update', 'Update app on the server'

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -131,16 +131,6 @@ module ZendeskAppsTools
     method_option :bind, required: false
     def server
       setup_path(options[:path])
-      manifest = app_package.manifest
-
-      require 'zendesk_apps_tools/settings'
-      settings_helper = ZendeskAppsTools::Settings.new(self)
-
-      settings = settings_helper.get_settings_from_file options[:config], manifest.original_parameters
-
-      unless settings
-        settings = settings_helper.get_settings_from_user_input manifest.original_parameters
-      end
 
       require 'zendesk_apps_tools/server'
       ZendeskAppsTools::Server.tap do |server|
@@ -167,6 +157,10 @@ module ZendeskAppsTools
       end
       app_name ||= get_value_from_stdin('Enter app name:')
       deploy_app(:post, '/api/v2/apps.json', name: app_name)
+      has_requirements = File.exist?(File.join(options[:path], 'requirements.json'))
+      say_status 'Install', 'installing'
+      install_app(has_requirements, app_id: cache.fetch('app_id'), settings: settings.merge(name: app_name))
+      say_status 'Install', 'OK'
     end
 
     desc 'update', 'Update app on the server'
@@ -203,6 +197,18 @@ module ZendeskAppsTools
 
     def setup_path(path)
       @destination_stack << relative_to_original_destination_root(path) unless @destination_stack.last == path
+    end
+
+    def settings
+      settings_helper.get_settings_from_file(options[:config], manifest.original_parameters) ||
+        settings_helper.get_settings_from_user_input(manifest.original_parameters)
+    end
+
+    def settings_helper
+      @settings_helper ||= begin
+        require 'zendesk_apps_tools/settings'
+        ZendeskAppsTools::Settings.new(self)
+      end
     end
   end
 end

--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -70,7 +70,7 @@ module ZendeskAppsTools
       say_error_and_exit job_response['error'] if job_response['error']
 
       if poll_job
-        job_id = job_response['job_id']
+        job_id = job_response['job_id'] || job_response['pending_job_id']
         check_job job_id
       end
     end

--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -88,7 +88,7 @@ module ZendeskAppsTools
         if %w(completed failed).include? status
           case status
           when 'completed'
-            cache.save 'app_id' => app_id
+            cache.save 'app_id' => app_id if app_id
             say_status @command, 'OK'
           when 'failed'
             say_status @command, message, :red

--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -16,6 +16,16 @@ module ZendeskAppsTools
       say_error_and_exit e.message
     end
 
+    def install_app(poll_job, installation)
+      connection = get_connection
+      response = connection.post do |req|
+        req.url 'api/v2/apps/installations.json'
+        req.headers[:content_type] = 'application/json'
+        req.body = JSON.generate(installation)
+      end
+      check_status(response, poll_job)
+    end
+
     def upload(path)
       connection = get_connection :multipart
       zipfile_path = options[:zipfile]
@@ -54,13 +64,15 @@ module ZendeskAppsTools
       say_error_and_exit e.message
     end
 
-    def check_status(response)
+    def check_status(response, poll_job = true)
       job = response.body
       job_response = json_or_die(job)
       say_error_and_exit job_response['error'] if job_response['error']
 
-      job_id = job_response['job_id']
-      check_job job_id
+      if poll_job
+        job_id = job_response['job_id']
+        check_job job_id
+      end
     end
 
     def check_job(job_id)

--- a/lib/zendesk_apps_tools/package_helper.rb
+++ b/lib/zendesk_apps_tools/package_helper.rb
@@ -6,6 +6,10 @@ module ZendeskAppsTools
       @app_package ||= ZendeskAppsSupport::Package.new(app_dir.to_s)
     end
 
+    def manifest
+      app_package.manifest
+    end
+
     def zip(archive_path)
       require 'zip'
       Zip::File.open(archive_path, 'w') do |zipfile|

--- a/lib/zendesk_apps_tools/package_helper.rb
+++ b/lib/zendesk_apps_tools/package_helper.rb
@@ -7,7 +7,7 @@ module ZendeskAppsTools
     end
 
     def manifest
-      app_package.manifest
+      @manifest ||= app_package.manifest
     end
 
     def zip(archive_path)

--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -1,5 +1,6 @@
 require 'sinatra/base'
 require 'sinatra/cross_origin'
+require 'zendesk_apps_support' # dependency of zendesk_apps_support/package
 require 'zendesk_apps_support/package'
 
 module ZendeskAppsTools

--- a/spec/lib/zendesk_apps_tools/command_spec.rb
+++ b/spec/lib/zendesk_apps_tools/command_spec.rb
@@ -52,11 +52,17 @@ describe ZendeskAppsTools::Command do
       it 'uploads a file and posts build api' do
         expect(@command).to receive(:upload).and_return(123)
         allow(@command).to receive(:check_status)
-        expect(File).to receive(:read) { '{ "name": "abc" }' }
+        expect(@command).to receive(:manifest).and_return(double('manifest', name: 'abc', original_parameters: [])).at_least(:once)
+        allow(@command).to receive(:options) { { clean: false, path: './', config: './settings.json' } }
 
         stub_request(:post, PREFIX + '/api/v2/apps.json')
           .with(body: JSON.generate(name: 'abc', upload_id: '123'),
                 headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
+
+        stub_request(:post, PREFIX + '/api/v2/apps/installations.json')
+          .with(body: JSON.generate(app_id: nil, settings: { name: 'abc' }),
+                headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=', 'Content-Type' => 'application/json' })
+
 
         @command.create
       end
@@ -66,13 +72,18 @@ describe ZendeskAppsTools::Command do
       it 'uploads the zipfile and posts build api' do
         expect(@command).to receive(:upload).and_return(123)
         allow(@command).to receive(:check_status)
-        allow(@command).to receive(:options) { { clean: false, path: './', zipfile: 'abc.zip' } }
+        allow(@command).to receive(:options) { { clean: false, path: './', zipfile: 'abc.zip', config: './settings.json' } }
+        expect(@command).to receive(:manifest).and_return(double('manifest', name: 'abc', original_parameters: [])).at_least(:once)
 
         expect(@command).to receive(:get_value_from_stdin) { 'abc' }
 
         stub_request(:post, PREFIX + '/api/v2/apps.json')
           .with(body: JSON.generate(name: 'abc', upload_id: '123'),
                 headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
+
+        stub_request(:post, PREFIX + '/api/v2/apps/installations.json')
+          .with(body: JSON.generate(app_id: nil, settings: { name: 'abc' }),
+                headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=', 'Content-Type' => 'application/json' })
 
         @command.create
       end

--- a/spec/lib/zendesk_apps_tools/command_spec.rb
+++ b/spec/lib/zendesk_apps_tools/command_spec.rb
@@ -53,16 +53,16 @@ describe ZendeskAppsTools::Command do
         expect(@command).to receive(:upload).and_return(123)
         allow(@command).to receive(:check_status)
         expect(@command).to receive(:manifest).and_return(double('manifest', name: 'abc', original_parameters: [])).at_least(:once)
-        allow(@command).to receive(:options) { { clean: false, path: './', config: './settings.json' } }
+        allow(@command).to receive(:options).and_return(clean: false, path: './', config: './settings.json', install: true)
+        allow(@command.cache).to receive(:fetch).with('app_id').and_return('987')
 
         stub_request(:post, PREFIX + '/api/v2/apps.json')
           .with(body: JSON.generate(name: 'abc', upload_id: '123'),
                 headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
 
         stub_request(:post, PREFIX + '/api/v2/apps/installations.json')
-          .with(body: JSON.generate(app_id: nil, settings: { name: 'abc' }),
+          .with(body: JSON.generate(app_id: '987', settings: { name: 'abc' }),
                 headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=', 'Content-Type' => 'application/json' })
-
 
         @command.create
       end
@@ -72,7 +72,7 @@ describe ZendeskAppsTools::Command do
       it 'uploads the zipfile and posts build api' do
         expect(@command).to receive(:upload).and_return(123)
         allow(@command).to receive(:check_status)
-        allow(@command).to receive(:options) { { clean: false, path: './', zipfile: 'abc.zip', config: './settings.json' } }
+        allow(@command).to receive(:options).and_return(clean: false, path: './', zipfile: 'abc.zip', config: './settings.json', install: true)
         expect(@command).to receive(:manifest).and_return(double('manifest', name: 'abc', original_parameters: [])).at_least(:once)
 
         expect(@command).to receive(:get_value_from_stdin) { 'abc' }


### PR DESCRIPTION
### Description

When you `zat create` you almost always go and install the app afterwards. This does it automatically.

cc @zendesk/vegemite @fvzzy 

### Todo

Poll the job when the installation has requirements

### Risks

- [low] `zat create` failing