### PR TITLE
just call validate rather than invoking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: ruby
+dist: trusty
 rvm:
   - 2.0
   - 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.1
   - 2.2.6
   - 2.3.3
+  - 2.4.0
 branches:
   only:
     - master

--- a/features/create.feature
+++ b/features/create.feature
@@ -1,0 +1,12 @@
+Feature: upload an app to the apps marketplace
+  Background: create a new zendesk app
+
+  Scenario: package a zendesk app by running 'zat create --no-install' command
+    Given an app is created in directory "tmp/aruba"
+    Given a .zat file in "tmp/aruba"
+    When I run the command "zat create --path tmp/aruba --no-install" to create the app
+    And the command output should contain "validate  OK"
+    And the command output should contain "package  created"
+    And the command output should contain "Status  working"
+    And the command output should contain "Create  OK"
+    And the zip file should exist in directory "tmp/aruba/tmp"

--- a/features/step_definitions/app_steps.rb
+++ b/features/step_definitions/app_steps.rb
@@ -57,7 +57,6 @@ end
 
 When /^I run the command "(.*?)" to (validate|package|clean|create) the app$/ do |cmd, _action|
   env_hash = prepare_env_hash_for(cmd)
-  cmd.sub!(/^zat/, File.expand_path('../../../bin/zat', __FILE__)) unless ENV['TRAVIS']
   IO.popen(env_hash, cmd, 'w+') do |pipe|
     pipe.puts "\n"
     pipe.close_write

--- a/features/step_definitions/app_steps.rb
+++ b/features/step_definitions/app_steps.rb
@@ -57,7 +57,7 @@ end
 
 When /^I run the command "(.*?)" to (validate|package|clean|create) the app$/ do |cmd, _action|
   env_hash = prepare_env_hash_for(cmd)
-  cmd.sub!(/^zat/, File.expand_path('../../../bin/zat', __FILE__))
+  cmd.sub!(/^zat/, File.expand_path('../../../bin/zat', __FILE__)) unless ENV['TRAVIS']
   IO.popen(env_hash, cmd, 'w+') do |pipe|
     pipe.puts "\n"
     pipe.close_write

--- a/features/step_definitions/app_steps.rb
+++ b/features/step_definitions/app_steps.rb
@@ -31,6 +31,12 @@ Given /^a(n|(?: v1)) app is created in directory "(.*?)"$/ do |version, app_dir|
     )
 end
 
+Given /^a \.zat file in "(.*?)"/ do |app_dir|
+  f = File.new(File.join(app_dir, '.zat'), 'w')
+  f.write(JSON.dump(username: 'test@user.com', password: 'hunter2', subdomain: 'app-account'))
+  f.close
+end
+
 When /^I run "(.*?)" command with the following details:$/ do |cmd, table|
   IO.popen(cmd, 'w+') do |pipe|
     # [ ['parameter name', 'value'] ]
@@ -49,8 +55,15 @@ When /^I create a symlink from "(.*?)" to "(.*?)"$/ do |src, dest|
   FileUtils.ln_s(src, dest)
 end
 
-When /^I run the command "(.*?)" to (validate|package|clean) the app$/ do |cmd, _action|
-  IO.popen(cmd, 'w+') do |pipe|
+When /^I run the command "(.*?)" to (validate|package|clean|create) the app$/ do |cmd, _action|
+  if cmd.start_with? 'zat create'
+    path = File.expand_path('../../support/webmock', __FILE__)
+    env_hash = { 'RUBYOPT' => "-r #{path}" }
+  else
+    env_hash = {}
+  end
+  cmd.sub!(/^zat/, File.expand_path('../../../bin/zat', __FILE__))
+  IO.popen(env_hash, cmd, 'w+') do |pipe|
     pipe.puts "\n"
     pipe.close_write
     @output = pipe.readlines

--- a/features/step_definitions/app_steps.rb
+++ b/features/step_definitions/app_steps.rb
@@ -56,12 +56,7 @@ When /^I create a symlink from "(.*?)" to "(.*?)"$/ do |src, dest|
 end
 
 When /^I run the command "(.*?)" to (validate|package|clean|create) the app$/ do |cmd, _action|
-  if cmd.start_with? 'zat create'
-    path = File.expand_path('../../support/webmock', __FILE__)
-    env_hash = { 'RUBYOPT' => "-r #{path}" }
-  else
-    env_hash = {}
-  end
+  env_hash = prepare_env_hash_for(cmd)
   cmd.sub!(/^zat/, File.expand_path('../../../bin/zat', __FILE__))
   IO.popen(env_hash, cmd, 'w+') do |pipe|
     pipe.puts "\n"

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 def prepare_env_hash_for(cmd)
   if cmd.start_with? 'zat create'
     path = File.expand_path('../../support/webmock', __FILE__)

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -2,7 +2,7 @@
 def prepare_env_hash_for(cmd)
   if cmd.start_with? 'zat create'
     path = File.expand_path('../../support/webmock', __FILE__)
-    { 'RUBYOPT' => "-r #{path}" }
+    { 'RUBYOPT' => "#{ENV['RUBYOPT']} -r #{path}" }
   else
     {}
   end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -1,0 +1,8 @@
+def prepare_env_hash_for(cmd)
+  if cmd.start_with? 'zat create'
+    path = File.expand_path('../../support/webmock', __FILE__)
+    { 'RUBYOPT' => "-r #{path}" }
+  else
+    {}
+  end
+end

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -1,10 +1,12 @@
-return if defined?(Cucumber)
+# frozen_string_literal: true
+unless defined?(Cucumber)
 
-require 'webmock'
+  require 'webmock'
 
-WebMock::API.stub_request(:post, 'https://app-account.zendesk.com/api/v2/apps/uploads.json').to_return(body: JSON.dump(id: '123'))
-WebMock::API.stub_request(:post, 'https://app-account.zendesk.com/api/v2/apps.json').with(body: JSON.dump(name: 'John Test App', upload_id: '123')).to_return(body: JSON.dump(job_id: '987'))
-WebMock::API.stub_request(:get, 'https://app-account.zendesk.com/api/v2/apps/job_statuses/987').to_return(body: JSON.dump(status: 'working')).then.to_return(body: JSON.dump(status: 'completed', app_id: '55'))
+  WebMock::API.stub_request(:post, 'https://app-account.zendesk.com/api/v2/apps/uploads.json').to_return(body: JSON.dump(id: '123'))
+  WebMock::API.stub_request(:post, 'https://app-account.zendesk.com/api/v2/apps.json').with(body: JSON.dump(name: 'John Test App', upload_id: '123')).to_return(body: JSON.dump(job_id: '987'))
+  WebMock::API.stub_request(:get, 'https://app-account.zendesk.com/api/v2/apps/job_statuses/987').to_return(body: JSON.dump(status: 'working')).then.to_return(body: JSON.dump(status: 'completed', app_id: '55'))
 
-WebMock.enable!
-WebMock.disable_net_connect!
+  WebMock.enable!
+  WebMock.disable_net_connect!
+end

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -1,0 +1,10 @@
+return if defined?(Cucumber)
+
+require 'webmock'
+
+WebMock::API.stub_request(:post, 'https://app-account.zendesk.com/api/v2/apps/uploads.json').to_return(body: JSON.dump(id: '123'))
+WebMock::API.stub_request(:post, 'https://app-account.zendesk.com/api/v2/apps.json').with(body: JSON.dump(name: 'John Test App', upload_id: '123')).to_return(body: JSON.dump(job_id: '987'))
+WebMock::API.stub_request(:get, 'https://app-account.zendesk.com/api/v2/apps/job_statuses/987').to_return(body: JSON.dump(status: 'working')).then.to_return(body: JSON.dump(status: 'completed', app_id: '55'))
+
+WebMock.enable!
+WebMock.disable_net_connect!

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+
+# we only want this file to monkey-patch zat when we shell out to it, but cucumber automatically requires it as well.
 unless defined?(Cucumber)
 
   require 'webmock'

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -92,7 +92,7 @@ module ZendeskAppsTools
     desc 'package', 'Package your app'
     shared_options(except: [:unattended])
     def package
-      return false unless invoke(:validate, [])
+      return false unless validate
 
       setup_path(options[:path])
 

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -152,6 +152,7 @@ module ZendeskAppsTools
     method_option :install, default: true, type: :boolean, desc: 'Also create an installation with some settings immediately after uploading.'
     def create
       cache.clear
+      setup_path(options[:path])
       @command = 'Create'
 
       unless options[:zipfile]
@@ -170,6 +171,7 @@ module ZendeskAppsTools
     method_option :zipfile, default: nil, required: false, type: :string
     def update
       cache.clear
+      setup_path(options[:path])
       @command = 'Update'
 
       app_id = cache.fetch('app_id') || find_app_id


### PR DESCRIPTION
### Description

`zat create --no-install` crashes because it passes the `--no-install` argument on to `validate`.

cc @zendesk/vegemite 

### References

https://zendesk-appdevelopers.slack.com/archives/C0L7VFW9G/p1490251653651834