### PR TITLE
at least try to serve the app even if assets/app.js exists

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -130,6 +130,9 @@ module ZendeskAppsTools
     method_option :app_id, default: DEFAULT_APP_ID, required: false, type: :numeric
     method_option :bind, required: false
     def server
+      if app_package.has_file?('assets/app.js')
+        say 'Warning: creating assets/app.js causes zat server to behave badly.', :yellow
+      end
       setup_path(options[:path])
 
       require 'zendesk_apps_tools/server'

--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -45,6 +45,9 @@ module ZendeskAppsTools
     end
 
     def send_file(*args)
+      # does the request look like a request from the host product for the generated
+      # installed.js file? If so, send that. Otherwise send the static file in the
+      # app's public_folder (./assets).
       if request.env['PATH_INFO'] == '/app.js' && params.key?('locale') && params.key?('subdomain')
         serve_installed_js
       else


### PR DESCRIPTION
### Description

Sinatra's static file serving seems to take precedence over our defined routes. This is bad in the case that we want to _generate_ `app.js` rather than just serve it from `assets/`.

Helpfully, we've already monkey patched its `send_file` method, so let's monkey patch some more.

cc @zendesk/vegemite @dashedstripes 

### Risks

- [low] `zat server` is broken for some apps