### PR TITLE
[APPS-3473] Multi Product - Use v3 app market endpoints and install in multiple products

### DIFF
--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -6,7 +6,7 @@ unless defined?(Cucumber)
   require 'webmock'
 
   WebMock::API.stub_request(:post, 'https://app-account.zendesk.com/api/v2/apps/uploads.json').to_return(body: JSON.dump(id: '123'))
-  WebMock::API.stub_request(:post, 'https://app-account.zendesk.com/api/v2/apps.json').with(body: JSON.dump(name: 'John Test App', upload_id: '123')).to_return(body: JSON.dump(job_id: '987'))
+  WebMock::API.stub_request(:post, 'https://app-account.zendesk.com/api/apps.json').with(body: JSON.dump(name: 'John Test App', upload_id: '123')).to_return(body: JSON.dump(job_id: '987'))
   WebMock::API.stub_request(:get, 'https://app-account.zendesk.com/api/v2/apps/job_statuses/987').to_return(body: JSON.dump(status: 'working')).then.to_return(body: JSON.dump(status: 'completed', app_id: '55'))
 
   WebMock.enable!

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -162,11 +162,14 @@ module ZendeskAppsTools
         app_name = manifest.name
       end
       app_name ||= get_value_from_stdin('Enter app name:')
-      deploy_app(:post, '/api/v2/apps.json', name: app_name)
+      deploy_app(:post, '/api/apps.json', name: app_name)
       has_requirements = File.exist?(File.join(options[:path], 'requirements.json'))
       return unless options[:install]
-      say_status 'Install', 'installing'
-      install_app(has_requirements, app_id: cache.fetch('app_id'), settings: settings.merge(name: app_name))
+      product_names = manifest.location_options.collect{ |option| option.location.product_code }.collect{ |code| ZendeskAppsSupport::Product.find_by( code: code ) }.collect(&:name)
+      product_names.each do |product_name|
+        say_status 'Install', "installing in #{product_name}"
+        install_app(has_requirements, product_name, app_id: cache.fetch('app_id'), settings: settings.merge(name: app_name))
+      end
     end
 
     desc 'update', 'Update app on the server'

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -165,8 +165,7 @@ module ZendeskAppsTools
       deploy_app(:post, '/api/apps.json', name: app_name)
       has_requirements = File.exist?(File.join(options[:path], 'requirements.json'))
       return unless options[:install]
-      product_names = manifest.location_options.collect{ |option| option.location.product_code }.collect{ |code| ZendeskAppsSupport::Product.find_by( code: code ) }.collect(&:name)
-      product_names.each do |product_name|
+      product_names(manifest).each do |product_name|
         say_status 'Install', "installing in #{product_name}"
         install_app(has_requirements, product_name, app_id: cache.fetch('app_id'), settings: settings.merge(name: app_name))
       end
@@ -193,6 +192,14 @@ module ZendeskAppsTools
     end
 
     protected
+
+    def product_names(manifest)
+      product_codes(manifest).collect{ |code| ZendeskAppsSupport::Product.find_by( code: code ) }.collect(&:name)
+    end
+
+    def product_codes(manifest)
+      manifest.location_options.collect{ |option| option.location.product_code } 
+    end
 
     def setup_path(path)
       @destination_stack << relative_to_original_destination_root(path) unless @destination_stack.last == path

--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -16,10 +16,10 @@ module ZendeskAppsTools
       say_error_and_exit e.message
     end
 
-    def install_app(poll_job, installation)
+    def install_app(poll_job, product_name, installation)
       connection = get_connection
       response = connection.post do |req|
-        req.url 'api/v2/apps/installations.json'
+        req.url "api/#{product_name}/apps/installations.json"
         req.headers[:content_type] = 'application/json'
         req.body = JSON.generate(installation)
       end

--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -52,7 +52,7 @@ module ZendeskAppsTools
 
       connection = get_connection
 
-      all_apps = connection.get('/api/v2/apps.json').body
+      all_apps = connection.get('/api/apps.json').body
 
       app_json = json_or_die(all_apps)['apps'].find { |app| app['name'] == name }
       say_error_and_exit('The app was not found. Please verify your credentials, subdomain, and app name are correct.') unless app_json

--- a/spec/lib/zendesk_apps_tools/command_spec.rb
+++ b/spec/lib/zendesk_apps_tools/command_spec.rb
@@ -17,6 +17,7 @@ describe ZendeskAppsTools::Command do
     allow(@command.cache).to receive(:save)
     allow(@command.cache).to receive(:clear)
     allow(@command).to receive(:options) { { clean: false, path: './' } }
+    allow(@command).to receive(:product_names).and_return(['support'])
   end
 
   describe '#upload' do
@@ -57,11 +58,11 @@ describe ZendeskAppsTools::Command do
         allow(@command).to receive(:options).and_return(clean: false, path: './', config: './settings.json', install: true)
         allow(@command.cache).to receive(:fetch).with('app_id').and_return('987')
 
-        stub_request(:post, PREFIX + '/api/v2/apps.json')
+        stub_request(:post, PREFIX + '/api/apps.json')
           .with(body: JSON.generate(name: 'abc', upload_id: '123'),
                 headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
 
-        stub_request(:post, PREFIX + '/api/v2/apps/installations.json')
+        stub_request(:post, PREFIX + '/api/support/apps/installations.json')
           .with(body: JSON.generate(app_id: '987', settings: { name: 'abc' }),
                 headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=', 'Content-Type' => 'application/json' })
 
@@ -78,11 +79,11 @@ describe ZendeskAppsTools::Command do
 
         expect(@command).to receive(:get_value_from_stdin) { 'abc' }
 
-        stub_request(:post, PREFIX + '/api/v2/apps.json')
+        stub_request(:post, PREFIX + '/api/apps.json')
           .with(body: JSON.generate(name: 'abc', upload_id: '123'),
                 headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
 
-        stub_request(:post, PREFIX + '/api/v2/apps/installations.json')
+        stub_request(:post, PREFIX + '/api/support/apps/installations.json')
           .with(body: JSON.generate(app_id: nil, settings: { name: 'abc' }),
                 headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=', 'Content-Type' => 'application/json' })
 
@@ -118,7 +119,7 @@ describe ZendeskAppsTools::Command do
           ]
         }
 
-        stub_request(:get, PREFIX + '/api/v2/apps.json')
+        stub_request(:get, PREFIX + '/api/apps.json')
           .with(headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
           .to_return(body: JSON.generate(apps))
 


### PR DESCRIPTION
#:bear:

/cc @zendesk/wombat
@zendesk/vegemite 

### Description
This is part of the multi product effort
`zat create` to install the app in all product locations found in manifest.
Depends on the ZAM PR listed below

### References
* JIRA: https://zendesk.atlassian.net/browse/APPS-3473
* ZAM PR: https://github.com/zendesk/zendesk_app_market/pull/2599

### Risks
* low - breaks app creation/installation
