### PR TITLE
Add guard for wrong path

### DIFF
--- a/lib/zendesk_apps_tools/package_helper.rb
+++ b/lib/zendesk_apps_tools/package_helper.rb
@@ -7,7 +7,11 @@ module ZendeskAppsTools
     end
 
     def manifest
-      @manifest ||= app_package.manifest
+      begin
+        @manifest ||= app_package.manifest
+      rescue
+        say_status "error", "Manifest file cannot be found in the given path. Check you are pointing to the path that contains your manifest.json", :red and exit 1
+      end
     end
 
     def zip(archive_path)


### PR DESCRIPTION
/cc @zendesk/vegemite 

## Description

Previously the error message when trying to run `zat s` in the wrong directory was unhelpful.

A guard has now been added that catches the previously uncaught error and displays a message guiding the user where to look.

![image](https://user-images.githubusercontent.com/754567/29200941-f48fbd5a-7e9c-11e7-82b8-d1d398701522.png)

## Steps to test
- Check out `nickf/better-error-handling` branch
- `bundle i`
- If you haven't already, set up an alias in your shell profile (.bash_profile, .zshrc, whatever you use), and change the path in the command  
for example: `alias zatdev='BUNDLE_GEMFILE=/path/to/repo/zendesk_apps_tools/Gemfile bundle exec /path/to/repo/zendesk_apps_tools/bin/zat'`  
You might need to `source` your profile to refresh the changes (or open a new Terminal window)
- Go to a folder that does not contain a `manifest.json`
- `zatdev s`
- See the error message
- Go to a folder that does contain a `manifest.json`
- `zatdev s`
- See the server starts properly