### PR TITLE
Add version checking

### DIFF
--- a/features/create.feature
+++ b/features/create.feature
@@ -5,6 +5,7 @@ Feature: upload an app to the apps marketplace
     Given an app is created in directory "tmp/aruba"
     Given a .zat file in "tmp/aruba"
     When I run the command "zat create --path tmp/aruba --no-install" to create the app
+    And the command output should contain "info  Checking for new version of zendesk_apps_tools"
     And the command output should contain "validate  OK"
     And the command output should contain "package  created"
     And the command output should contain "Status  working"

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -8,6 +8,7 @@ unless defined?(Cucumber)
   WebMock::API.stub_request(:post, 'https://app-account.zendesk.com/api/v2/apps/uploads.json').to_return(body: JSON.dump(id: '123'))
   WebMock::API.stub_request(:post, 'https://app-account.zendesk.com/api/apps.json').with(body: JSON.dump(name: 'John Test App', upload_id: '123')).to_return(body: JSON.dump(job_id: '987'))
   WebMock::API.stub_request(:get, 'https://app-account.zendesk.com/api/v2/apps/job_statuses/987').to_return(body: JSON.dump(status: 'working')).then.to_return(body: JSON.dump(status: 'completed', app_id: '55'))
+  WebMock::API.stub_request(:get, 'https://rubygems.org/api/v1/gems/zendesk_apps_tools.json').to_return(body: JSON.dump(status: 'working')).then.to_return(body: JSON.dump(name: 'zendesk_apps_tools', version: '2.1.1'))
 
   WebMock.enable!
   WebMock.disable_net_connect!

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -63,6 +63,7 @@ module ZendeskAppsTools
     desc 'validate', 'Validate your app'
     shared_options(except: [:unattended])
     def validate
+      check_for_updates
       setup_path(options[:path])
       begin
         errors = app_package.validate(marketplace: false)
@@ -201,7 +202,7 @@ module ZendeskAppsTools
     end
 
     def product_codes(manifest)
-      manifest.location_options.collect{ |option| option.location.product_code } 
+      manifest.location_options.collect{ |option| option.location.product_code }
     end
 
     def setup_path(path)

--- a/lib/zendesk_apps_tools/common.rb
+++ b/lib/zendesk_apps_tools/common.rb
@@ -72,27 +72,6 @@ module ZendeskAppsTools
       say_error_and_exit value
     end
 
-    def check_for_updates
-      begin
-        require 'net/http'
-
-        return unless (cache.fetch "zat_update_check").nil? || Date.parse(cache.fetch "zat_update_check") < Date.today - 7
-
-        say_status 'info', 'Checking for new version of zendesk_apps_tools'
-        response = Net::HTTP.get_response(URI('https://rubygems.org/api/v1/gems/zendesk_apps_tools.json'))
-
-        latest_version = Gem::Version.new(JSON.parse(response.body)["version"])
-        current_version = Gem::Version.new(ZendeskAppsTools::VERSION)
-
-        cache.save 'zat_latest' => latest_version
-        cache.save 'zat_update_check' => Date.today
-
-        say_status 'warning', 'Your version of Zendesk Apps Tools is outdated. Update by running: gem update zendesk_apps_tools', :yellow if current_version < latest_version
-      rescue SocketError
-        say_status 'warning', 'Unable to check for new versions of zendesk_apps_tools gem', :yellow
-      end
-    end
-
     private
 
     def error_or_default_if_unattended(prompt, opts = {})

--- a/lib/zendesk_apps_tools/common.rb
+++ b/lib/zendesk_apps_tools/common.rb
@@ -72,6 +72,27 @@ module ZendeskAppsTools
       say_error_and_exit value
     end
 
+    def check_for_updates
+      begin
+        require 'net/http'
+
+        return unless (cache.fetch "zat_update_check").nil? || Date.parse(cache.fetch "zat_update_check") < Date.today - 7
+
+        say_status 'info', 'Checking for new version of zendesk_apps_tools'
+        response = Net::HTTP.get_response(URI('https://rubygems.org/api/v1/gems/zendesk_apps_tools.json'))
+
+        latest_version = Gem::Version.new(JSON.parse(response.body)["version"])
+        current_version = Gem::Version.new(ZendeskAppsTools::VERSION)
+
+        cache.save 'zat_latest' => latest_version
+        cache.save 'zat_update_check' => Date.today
+
+        say_status 'warning', 'Your version of Zendesk Apps Tools is outdated. Update by running: gem update zendesk_apps_tools', :yellow if current_version < latest_version
+      rescue SocketError
+        say_status 'warning', 'Unable to check for new versions of zendesk_apps_tools gem', :yellow
+      end
+    end
+
     private
 
     def error_or_default_if_unattended(prompt, opts = {})


### PR DESCRIPTION
/cc @zendesk/vegemite 

## Description
Add version checking to ZAT.

When a check is made, the version number and the date it was last checked are both saved to the `.zat` file for caching and so it wouldn't happen every time the validate command was called. Currently it will only check if the last time a check was made was more than a week ago.

Checks are performed by querying the RubyGems API for the version.

The cached values are only saved to the project's local `.zat` file, as opposed to a global, root `.zat` file. Maybe that could be a future feature improvement.

## Steps to test
- Check out `nickf/add-version-checks` branch
- `bundle i`
- If you haven't already, set up an alias in your shell profile (.bash_profile, .zshrc, whatever you use), and change the path in the command  
for example: `alias zatdev='BUNDLE_GEMFILE=/path/to/repo/zendesk_apps_tools/Gemfile bundle exec /path/to/repo/zendesk_apps_tools/bin/zat'`  
You might need to `source` your profile to refresh the changes (or open a new Terminal window)
- Go to a folder that contains an app
- `zatdev validate`
- See that the check is performed and results are appended to `.zat`
- `zatdev validate` again
- See that the checks aren't performed again