### PR TITLE
Bump ZAS to v4.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       sinatra (~> 1.4.6)
       sinatra-cross_origin (~> 0.3.1)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 3.5.0)
+      zendesk_apps_support (~> 4.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -101,7 +101,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    zendesk_apps_support (3.5.0)
+    zendesk_apps_support (4.0.0)
       erubis
       i18n
       image_size
@@ -123,4 +123,4 @@ DEPENDENCIES
   zendesk_apps_tools!
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rubyzip',     '~> 1.2.1'
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 3.5.0'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.0.0'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
 
   s.add_development_dependency 'cucumber'


### PR DESCRIPTION
Bumping ZAS version to support new chat background app location.

Chat FE PR: https://github.com/zopim/meshim-frontend/pull/3473
ZAS Changes: https://github.com/zendesk/zendesk_apps_support/pull/173

@zendesk/vegemite 