### PR TITLE
Add require statement for ExecJS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     zendesk_apps_tools (2.2.1)
+      execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       rubyzip (~> 1.2.1)
       sinatra (~> 1.4.6)

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -63,6 +63,7 @@ module ZendeskAppsTools
     desc 'validate', 'Validate your app'
     shared_options(except: [:unattended])
     def validate
+      require 'execjs'
       check_for_update
       setup_path(options[:path])
       begin

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rubyzip',     '~> 1.2.1'
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
+  s.add_runtime_dependency 'execjs',      '~> 2.7.0'
   s.add_runtime_dependency 'zendesk_apps_support', '~> 4.2.0'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
 


### PR DESCRIPTION
/cc @zendesk/vegemite 

### Description
Stops `zat validate` from completely falling over.