### PR TITLE
Bump ZAS to v4.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       sinatra (~> 1.4.6)
       sinatra-cross_origin (~> 0.3.1)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.0.0)
+      zendesk_apps_support (~> 4.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -101,7 +101,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    zendesk_apps_support (4.0.0)
+    zendesk_apps_support (4.2.0)
       erubis
       i18n
       image_size

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rubyzip',     '~> 1.2.1'
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.0.0'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.2.0'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
 
   s.add_development_dependency 'cucumber'


### PR DESCRIPTION
/cc @zendesk/vegemite 

## Description
Wombat have made some ZAS bumps recently. This PR makes ZAT use the latest version of ZAS.

### ZAS Changes
[From v4.0.0 to v4.1.0](https://github.com/zendesk/zendesk_apps_support/compare/v4.0.0...v4.1.0):
- Updated some translation strings

[From v4.1.0 to v4.2.0](https://github.com/zendesk/zendesk_apps_support/compare/v4.1.0...v4.2.0):
- Only remove name in translation.json for non-default locale

## Risks
- [low] Strings aren't removed from default locale JSON, but will be ignored from other places so not a big worry.