### PR TITLE
[AF-775] Create ZAT migrate command

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -193,6 +193,7 @@ module ZendeskAppsTools
 
     desc 'migrate', 'Helps with the migration of a v1 app to v2'
     shared_options(except: [:unattended, :clean])
+    method_option %s(replace-v1), default: false, required: false, type: :boolean, aliases: '-r'
     method_option :auto, default: false, required: false, type: :boolean, aliases: '-a'
     def migrate
       cache.clear
@@ -248,6 +249,7 @@ module ZendeskAppsTools
 
     def migrate_app(options = {})
       cmds = ["app_migrator", "migrate", "--path=#{options[:path]}"]
+      cmds << "--replace-v1" if options[:"replace-v1"]
       cmds << "--auto" if options[:auto]
       system(*cmds)
     end

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -199,13 +199,16 @@ module ZendeskAppsTools
       cache.clear
       setup_path(options[:path])
       @command = 'Migrate'
-      unless migration_helper_installed
+      say_error_and_exit("Node.js and NPM are required to use the Zendesk App Migration Helper \
+                          Please see installation instructions at https://nodejs.org/en/download/") unless package_installed('npm')
+      unless package_installed('app_migrator')
         try_install = get_value_from_stdin("The Zendesk App Migration Helper isn't installed yet. Would you like to try installing now?", limited_to: ['y', 'yes', 'n', 'no'], default: 'y' )
         say_error_and_exit("Please install the Zendesk App Migration Helper before running this command") if (try_install =~ /^y(es)?$/).nil? # thats a no
+        install_migration_helper
         say_error_and_exit("Unable to install the Zendesk App Migration Helper \
                             Please follow the installation instructions at \
                             https://github.com/zendesk/zendesk_app_migrator \
-                            before running this command again") unless install_migration_helper
+                            before running this command again") unless package_installed('app_migrator')
       end
       migrate_app(options)
     end
@@ -217,30 +220,8 @@ module ZendeskAppsTools
 
     protected
 
-    def migration_helper_installed
-      is_semver(app_migrator_version)
-    end
-
-    def node_js_installed
-      !!system("npm -v", out: File::NULL)
-    end
-
-    def app_migrator_version
-      say_error_and_exit("Node.js and NPM are required to use the Zendesk App Migration Helper \
-                          Please see installation instructions at https://nodejs.org/en/download/") unless node_js_installed
-      @migrator_version ||= begin
-        IO.popen("npm ls -g --depth=0 | grep zendesk_app_migrator") do |ls_io|
-          version = ls_io.read
-          version = version.split('@').last
-          return version if version.nil?
-          version.gsub!(/\n/, '')
-          version.strip
-        end
-      end
-    end
-
-    def is_semver(version = '')
-      !(/^v?(\d+\.)?(\d+\.)?(\*|\d+)$/ =~ version).nil?
+    def package_installed(package_name)
+      !!system(package_name, "--version", out: File::NULL)
     end
 
     def install_migration_helper

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -191,7 +191,7 @@ module ZendeskAppsTools
       deploy_app(:put, "/api/v2/apps/#{app_id}.json", {})
     end
 
-    desc 'migrate', 'Help get started with migrating an app from v1 to v2'
+    desc 'migrate', 'Helps with the migration of a v1 app to v2'
     shared_options(except: [:unattended, :clean])
     method_option :auto, default: false, required: false, type: :boolean, aliases: '-a'
     def migrate
@@ -201,11 +201,10 @@ module ZendeskAppsTools
       unless migration_helper_installed
         try_install = get_value_from_stdin("The Zendesk App Migration Helper isn't installed. Would you like to try installing now?", limited_to: ['y', 'n'], default: 'y' )
         say_error_and_exit("Please install the Zendesk App Migration Helper before running this command") unless try_install == "y"
-        install_migration_helper
         say_error_and_exit("Unable to install the Zendesk App Migration Helper \
                             Please follow the installation instructions at \
                             https://github.com/zendesk/zendesk_app_migrator \
-                            before running this command again") unless migration_helper_installed
+                            before running this command again") unless install_migration_helper
       end
       migrate_app(options)
     end
@@ -218,7 +217,7 @@ module ZendeskAppsTools
     protected
 
     def migration_helper_installed
-      (/^(\d+\.)?(\d+\.)?(\*|\d+)$/ =~ migration_helper_version) >= 0
+      !(/^(\d+\.)?(\d+\.)?(\*|\d+)$/ =~ migration_helper_version).nil?
     end
 
     def migration_helper_version
@@ -233,7 +232,7 @@ module ZendeskAppsTools
 
     def migrate_app(options = {})
       cmds = ["app_migrator", "migrate", "--path=#{options[:path]}"]
-      cmds << "--auto=#{options[:auto]}" if options[:auto]
+      cmds << "--auto" if options[:auto]
       system(*cmds)
     end
 

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -191,12 +191,51 @@ module ZendeskAppsTools
       deploy_app(:put, "/api/v2/apps/#{app_id}.json", {})
     end
 
+    desc 'migrate', 'Help get started with migrating an app from v1 to v2'
+    shared_options(except: [:unattended, :clean])
+    method_option :auto, default: false, required: false, type: :boolean, aliases: '-a'
+    def migrate
+      cache.clear
+      setup_path(options[:path])
+      @command = 'Migrate'
+      unless migration_helper_installed
+        try_install = get_value_from_stdin("The Zendesk App Migration Helper isn't installed. Would you like to try installing now?", limited_to: ['y', 'n'], default: 'y' )
+        say_error_and_exit("Please install the Zendesk App Migration Helper before running this command") unless try_install == "y"
+        install_migration_helper
+        say_error_and_exit("Unable to install the Zendesk App Migration Helper \
+                            Please follow the installation instructions at \
+                            https://github.com/zendesk/zendesk_app_migrator \
+                            before running this command again") unless migration_helper_installed
+      end
+      migrate_app(options)
+    end
+
     desc "version, -v", "Print the version"
     def version
       say ZendeskAppsTools::VERSION
     end
 
     protected
+
+    def migration_helper_installed
+      (/^(\d+\.)?(\d+\.)?(\*|\d+)$/ =~ migration_helper_version) >= 0
+    end
+
+    def migration_helper_version
+      v = `app_migrator --version`
+      return '' if v.nil?
+      v.gsub(/\n/, '')
+    end
+
+    def install_migration_helper
+      system("npm install -g zendesk_app_migrator")
+    end
+
+    def migrate_app(options = {})
+      cmds = ["app_migrator", "migrate", "--path=#{options[:path]}"]
+      cmds << "--auto=#{options[:auto]}" if options[:auto]
+      system(*cmds)
+    end
 
     def product_names(manifest)
       product_codes(manifest).collect{ |code| ZendeskAppsSupport::Product.find_by( code: code ) }.collect(&:name)

--- a/spec/lib/zendesk_apps_tools/command_spec.rb
+++ b/spec/lib/zendesk_apps_tools/command_spec.rb
@@ -203,8 +203,8 @@ describe ZendeskAppsTools::Command do
 
     context 'when node and npm are not installed' do
       before do
-        allow(IO).to receive(:popen)
-        allow(@command).to receive(:node_js_installed).and_return(false)
+        allow(@command).to receive(:package_installed).with('npm').and_return(false)
+        allow(@command).to receive(:package_installed).with('app_migrator').and_return(false)
       end
 
       it 'asks the user to install node.js manually' do
@@ -216,14 +216,12 @@ describe ZendeskAppsTools::Command do
 
     context 'when node and npm are installed' do
       before do
-        allow(@command).to receive(:node_js_installed).and_return(true)
-        allow(@command).to receive(:is_semver).and_call_original
+        allow(@command).to receive(:package_installed).with('npm').and_return(true)
       end
 
       context 'and the migrator is not installed' do
         before do
-          allow(IO).to receive(:popen).and_return('3.2.1')
-          allow(@command).to receive(:app_migrator_version).and_return('')
+          allow(@command).to receive(:package_installed).with('app_migrator').and_return(false)
         end
 
         it 'tries to install the migration helper, when given permission' do
@@ -242,7 +240,7 @@ describe ZendeskAppsTools::Command do
 
       context 'and the migrator is installed' do
         before do
-          allow(@command).to receive(:app_migrator_version).and_return('1.2.3')
+          allow(@command).to receive(:package_installed).with('app_migrator').and_return(true)
         end
 
         it 'runs the migration helper without trying to install' do


### PR DESCRIPTION
✌️ 

/cc @zendesk/vegemite 

### Overview
Adds support for a `zat migrate` command that will shell out to the [Zendesk App Migration Helper](https://github.com/zendesk/zendesk_app_migrator).

Before attempting to run the Migration Helper, zat will:
1. Check whether Node.js is installed (and by extension, NPM)
1. Check whether the App Migration Helper is installed
1. Run the App Migration Helper (with any options passed to zat)

### Todo
- [x] Add tests
- [x] Add support for `--replace-v1` option cf5adf2

### References
- https://zendesk.atlassian.net/browse/AF-775

### Risks
- N/A