### PR TITLE
Re-enable logging for server

### DIFF
--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -6,6 +6,7 @@ require 'zendesk_apps_support/package'
 module ZendeskAppsTools
   class Server < Sinatra::Base
     set :server, :thin
+    set :logging, true
     set :protection, except: :frame_options
     ZENDESK_DOMAINS_REGEX = %r{^http(?:s)?://[a-z0-9-]+\.(?:zendesk|zopim|zd-(?:dev|master|staging))\.com$}
 


### PR DESCRIPTION
After switching to thin from webbrick, the logging for the server has stoped. Currently logging for the sever in v2.4.0 results in the following:

```
▶ bundle exec ruby bin/zat s --path=../foobar_foobar
Enter a value for optional parameter 'token' or press 'Return' to skip:

== Sinatra (v1.4.8) has taken the stage on 4567 for development with backup from Thin
Thin web server (v1.7.2 codename Bachmanity)
Maximum connections set to 1024
Listening on localhost:4567, CTRL+C to stop
^CStopping ...
Stopping ...
== Sinatra has ended his set (crowd applauds)
```

This PR would re-enable logging for the server. Which would result in the following:

```
▶ bundle exec ruby bin/zat s --path=../foobar_foobar
Enter a value for optional parameter 'token' or press 'Return' to skip:

== Sinatra (v1.4.8) has taken the stage on 4567 for development with backup from Thin
Thin web server (v1.7.2 codename Bachmanity)
Maximum connections set to 1024
Listening on localhost:4567, CTRL+C to stop
::1 - - [03/Oct/2017:10:32:48 -0500] "GET /app.js?locale=en-GB&subdomain=pchhetri HTTP/1.1" 200 875 0.2405
::1 - - [03/Oct/2017:10:32:59 -0500] "GET /iframe.html?origin=https%3A%2F%2Fpchhetri.zendesk.com&app_guid=2884585d-c35e-491c-8083-ee7c1b2db2d0 HTTP/1.1" 200 1359 0.0008
::1 - - [03/Oct/2017:10:32:59 -0500] "GET /logo-small.png HTTP/1.1" 304 - 0.0005
^CStopping ...
Stopping ...
== Sinatra has ended his set (crowd applauds)
```

Reference: [ZD 3006714](https://support.zendesk.com/agent/tickets/3006714)
CC: @zendesk/vegemite 

JIRA: https://zendesk.atlassian.net/browse/AF-890