### PR TITLE
Fix silent zat update failure when app_id is not found

### DIFF
--- a/lib/zendesk_apps_tools/common.rb
+++ b/lib/zendesk_apps_tools/common.rb
@@ -69,7 +69,7 @@ module ZendeskAppsTools
       require 'json'
       JSON.parse(value)
     rescue JSON::ParserError
-      say_error_and_exit value
+      say_error_and_exit "\"#{value}\" is an invalid JSON"
     end
 
     private

--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -54,7 +54,7 @@ module ZendeskAppsTools
 
       all_apps = connection.get('/api/apps.json').body
 
-      app_json = json_or_die(all_apps)['apps'].find { |app| app['name'] == name }
+      app_json = all_apps.empty? ? nil : json_or_die(all_apps)['apps'].find { |app| app['name'] == name }
       say_error_and_exit('The app was not found. Please verify your credentials, subdomain, and app name are correct.') unless app_json
       app_id = app_json['id']
 

--- a/spec/lib/zendesk_apps_tools/common_spec.rb
+++ b/spec/lib/zendesk_apps_tools/common_spec.rb
@@ -75,4 +75,16 @@ describe ZendeskAppsTools::Common do
       subject.class.shared_options(except: [:clean])
     end
   end
+
+  describe 'json_or_die' do
+    it 'return json object if valid input is provided' do
+      expect(subject).not_to receive(:say)
+      expect(subject.json_or_die '{ "key":"value" }').to eq({ 'key'=>'value' })
+    end
+
+    it 'raise error if invalid input is provided' do
+      expect(subject).to receive(:say).with(/is an invalid JSON$/, :red)
+      expect { subject.json_or_die '{ "key"="value" }' }.to raise_error(SystemExit)
+    end
+  end
 end


### PR DESCRIPTION
✌️

/cc @zendesk/vegemite 

**Overview**

Currently `zat update` fails silently when `app_id` cannot be found. Here's what is happening:
- We query `apps.json` endpoint and pass the response to `JSON.parse`. The response might be empty string due to many reasons: wrong credentials, no internet connection, etc
- When `JSON.parse(value)` fails, we use `value` itself as error message. However, `value` is empty string so it simply goes silent.

**Todo**
- [x] Add check for `apps.json` response before attempting to parse it, so the error message is more relevant in this context (`The app was not found` vs `Invalid JSON`)
- [x] Raise more meaningful error message when `JSON.parse` fails
- [x] Update tests

**References**
https://zendesk.atlassian.net/browse/AF-858

**Risks**
N/A