### PR TITLE
do not hide errors like json parse errors

### DIFF
--- a/lib/zendesk_apps_tools/package_helper.rb
+++ b/lib/zendesk_apps_tools/package_helper.rb
@@ -9,7 +9,7 @@ module ZendeskAppsTools
     def manifest
       begin
         @manifest ||= app_package.manifest
-      rescue
+      rescue Errno::ENOENT
         say_status "error", "Manifest file cannot be found in the given path. Check you are pointing to the path that contains your manifest.json", :red and exit 1
       end
     end


### PR DESCRIPTION
had an error in my json and zat kept telling me that the file does not exist ... not very helpful ...

with this change it now shows the full backtrace, which is much more helpful
```
/opt/boxen/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/json-2.0.2/lib/json/common.rb:156:in `parse': 743: unexpected token at '{ (JSON::ParserError)
  "name": "Agent Satisfaction App",
  "author": {
```

... but still fails nicely when the file is indeed missing

@chucknado @zendesk/vegemite
