### PR TITLE
[AF-952] Bump ZAS to v4.6.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.7.2)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.6.1)
+      zendesk_apps_support (~> 4.6.4)
 
 GEM
   remote: https://rubygems.org/
@@ -37,7 +37,7 @@ GEM
     contracts (0.15.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.2)
+    crass (1.0.3)
     cucumber (2.4.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
@@ -49,7 +49,7 @@ GEM
     cucumber-core (1.5.0)
       gherkin (~> 4.0)
     cucumber-wire (0.0.1)
-    daemons (1.2.4)
+    daemons (1.2.5)
     diff-lcs (1.3)
     erubis (2.7.0)
     eventmachine (1.2.5)
@@ -63,7 +63,7 @@ GEM
     gherkin (4.1.1)
     hashdiff (0.3.2)
     hitimes (1.2.6)
-    i18n (0.9.0)
+    i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     image_size (1.5.0)
     jshintrb (0.3.0)
@@ -90,7 +90,7 @@ GEM
       rack
     rack-protection (1.5.3)
       rack
-    rake (12.1.0)
+    rake (12.3.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -109,7 +109,7 @@ GEM
     rspec-support (3.5.0)
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
-    sass (3.5.2)
+    sass (3.5.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -137,8 +137,8 @@ GEM
       hashdiff
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
-    zendesk_apps_support (4.6.1)
+    websocket-extensions (0.1.3)
+    zendesk_apps_support (4.6.4)
       erubis
       i18n
       image_size

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.6.1'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.6.4'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'
   s.add_runtime_dependency 'rack-livereload'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite 

### Description
Bump ZAS to replace SVGs containing embedded bitmaps with a placeholder SVG.

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-952
* ZAS PR: https://github.com/zendesk/zendesk_apps_support/pull/194

### Risks
* None/Low - new sanitisation rules cause validation to fail.