### PR TITLE
[ZD3408278][AF-1046] 'zat' errors out on 'clean' with "uninitialized" FileUtils

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -120,6 +120,8 @@ module ZendeskAppsTools
     desc 'clean', 'Remove app packages in temp folder'
     method_option :path, default: './', required: false, aliases: '-p'
     def clean
+      require 'fileutils'
+      
       setup_path(options[:path])
 
       return unless File.exist?(Pathname.new(File.join(app_dir, 'tmp')).to_s)


### PR DESCRIPTION
✌️

### Description
When running ZAT commands under certain Ruby versions, the `FileUtils` class wasn't being auto-loaded, resulting in a `NameError`.

```
c:/Ruby23/lib/ruby/gems/2.3.0/gems/zendesk_apps_tools-2.8.3/lib/zendesk_apps_tools/command.rb:128:in `clean': uninitialized constant ZendeskAppsTools::Command::FileUtils (NameError)
Did you mean?  FileTest
        from c:/Ruby23/lib/ruby/gems/2.3.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
...
```

### References
- Ticket: https://support.zendesk.com/agent/tickets/3408278

### Risk
- [low] The explicit require should work in all scenarios, making an auto-load unnecessary