### PR TITLE
Add command to merge marketplace content into en.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: ruby
 dist: trusty
 rvm:
-  - 2.0
   - 2.1
   - 2.2.6
   - 2.3.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.7.2)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.10.0)
+      zendesk_apps_support (~> 4.11.1)
 
 GEM
   remote: https://rubygems.org/
@@ -52,7 +52,7 @@ GEM
     daemons (1.2.6)
     diff-lcs (1.3)
     erubis (2.7.0)
-    eventmachine (1.2.5)
+    eventmachine (1.2.7)
     execjs (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -65,7 +65,7 @@ GEM
     hitimes (1.2.6)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
-    image_size (1.5.0)
+    image_size (2.0.0)
     jshintrb (0.3.0)
       execjs
       multi_json (>= 1.3)
@@ -78,14 +78,14 @@ GEM
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     multi_json (1.13.1)
     multi_test (0.1.2)
     multipart-post (2.0.0)
-    nokogiri (1.6.8.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     public_suffix (2.0.5)
-    rack (1.6.9)
+    rack (1.6.10)
     rack-livereload (0.3.17)
       rack
     rack-protection (1.5.5)
@@ -138,14 +138,14 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    zendesk_apps_support (4.10.0)
+    zendesk_apps_support (4.11.1)
       erubis
       i18n
       image_size
       jshintrb (~> 0.3.0)
       json
-      loofah
-      nokogiri (~> 1.6.8)
+      loofah (~> 2.2.1)
+      nokogiri (~> 1.8.1)
       sass
       sassc (~> 1.11.2)
 

--- a/features/merge_markdown.feature
+++ b/features/merge_markdown.feature
@@ -1,0 +1,25 @@
+Feature: merge markdown marketplace content files into en.json
+
+  Background: create a new zendesk app
+    Given an app is created in directory "tmp/aruba"
+    Given .md files in "tmp/aruba/translations"
+    And I move to the app directory
+
+  Scenario: merge marketplace content for a zendesk app by running 'zat merge_markdown -o' command
+    When I run the command "zat merge_markdown -o" to package the app
+    And the command output should contain "Reading installation_instructions.md"
+    And the command output should contain "Reading long_description.md"
+    And the command output should contain "Overwriting the current value of long_description in en.json"
+    And the command output should contain "Overwriting the current value of installation_instructions in en.json"
+    And the command output should contain "Writing to en.json"
+    Then the app file "translations/en.json" is created with:
+"""
+{"app": {"name": "Zen Tunes","short_description": "Play the famous zen tunes in your help desk.","long_description": "# Description \\n What a good app","installation_instructions": "# Instructions \\n _cool markdown_\\n\\n [markdown is](very cool)"}}
+"""
+   And I reset the working directory
+
+  Scenario: merge marketplace content for a zendesk app by running 'zat merge_markdown' command
+    When I run the command "zat merge_markdown" to package the app
+    And the command output should contain "Reading long_description.md"
+    Then the command output should contain "You already have a value for long_description in en.json. Please remove it or use the -o flag"
+   And I reset the working directory

--- a/features/step_definitions/app_steps.rb
+++ b/features/step_definitions/app_steps.rb
@@ -31,6 +31,15 @@ Given /^a(n|(?: v1)) app is created in directory "(.*?)"$/ do |version, app_dir|
     )
 end
 
+Given /^\.md files in "(.*?)"/ do |translations_dir|
+  f = File.new(File.join(translations_dir, 'installation_instructions.md'), 'w')
+  f.write('# Instructions \n _cool markdown_ \n\n [markdown is](very cool)')
+  f.close
+  f = File.new(File.join(translations_dir, 'long_description.md'), 'w')
+  f.write('# Description \n What a good app')
+  f.close
+end
+
 Given /^a \.zat file in "(.*?)"/ do |app_dir|
   f = File.new(File.join(app_dir, '.zat'), 'w')
   f.write(JSON.dump(username: 'test@user.com', password: 'hunter2', subdomain: 'app-account'))

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -316,14 +316,15 @@ module ZendeskAppsTools
         say_status 'info', 'Checking for new version of zendesk_apps_tools'
         response = Net::HTTP.get_response(URI('https://rubygems.org/api/v1/gems/zendesk_apps_tools.json'))
 
-        latest_version = Gem::Version.new(JSON.parse(response.body)["version"])
+        latest_version = Gem::Version.new(JSON.parse(response.body).fetch('version'))
+
         current_version = Gem::Version.new(ZendeskAppsTools::VERSION)
 
         cache.save 'zat_latest' => latest_version
         cache.save 'zat_update_check' => Date.today
 
         say_status 'warning', 'Your version of Zendesk Apps Tools is outdated. Update by running: gem update zendesk_apps_tools', :yellow if current_version < latest_version
-      rescue SocketError
+      rescue SocketError, KeyError
         say_status 'warning', 'Unable to check for new versions of zendesk_apps_tools gem', :yellow
       end
     end

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -118,6 +118,36 @@ module ZendeskAppsTools
       true
     end
 
+    desc 'merge_markdown', 'Merge .md marketplace content files into en.json'
+    method_option :overwrite, required: false, aliases: '-o'
+    def merge_markdown 
+      if Dir["#{app_dir}/translations/en.json"].empty?
+        say_status 'merge_markdown', "Please create a translations/en.json first", :red
+        return false
+      end
+      
+      translation_files = Dir["#{app_dir}/translations/{long_description,installation_instructions}.md"]
+      en_json = JSON.parse(File.read("#{app_dir}/translations/en.json"))
+
+      translation_files.each do |file_name|
+        translation_key = File.basename(file_name, '.md')
+        say_status 'merge_markdown', "Reading #{translation_key}.md"
+        unless en_json['app'][translation_key].to_s.empty?
+          if options[:overwrite]
+            say_status 'merge_markdown', "Overwriting the current value of #{translation_key} in en.json", :yellow
+          else
+            say_status 'merge_markdown', "You already have a value for #{translation_key} in en.json. Please remove it or use the -o flag", :red
+            return false
+          end
+        end
+        en_json['app'][translation_key] = File.read(file_name)
+      end
+
+      say_status 'merge_markdown', "Writing to en.json"
+      File.write("#{app_dir}/translations/en.json", en_json.to_json)
+      true
+    end
+
     desc 'clean', 'Remove app packages in temp folder'
     method_option :path, default: './', required: false, aliases: '-p'
     def clean

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Tools to help you develop Zendesk Apps.'
   s.description = s.summary
 
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.1'
   s.required_rubygems_version = '>= 1.3.6'
 
   s.add_runtime_dependency 'thor',        '~> 0.19.4'

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.10.0'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.11.1'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'
   s.add_runtime_dependency 'rack-livereload'


### PR DESCRIPTION
Will merge `.md` files in translations into your `en.json`, letting you write markdown-aware fields in a markdown editor without having to cram it all into one line (and escape newlines) yourself.

Also fixes a bug where if we get a `nil` when trying to get the response version, we show a warning (we used to just silently ignore it unless the request itself failed).

FYI: drops support for Ruby 2.0, since it's incompatible with the nokogiri version we need to use for security reasons. Do not merge until we figure out if we need to communicate this breaking change.
