### PR TITLE
ZD3725488 Exit early when app ID is invalid

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -191,10 +191,12 @@ module ZendeskAppsTools
       @command = 'Update'
 
       app_id = cache.fetch('app_id') || find_app_id
-      unless /\d+/ =~ app_id.to_s
+      app_url = "/api/v2/apps/#{app_id}.json"
+      unless /\d+/ =~ app_id.to_s && check_app_installed(app_url)
         say_error_and_exit "App id not found\nPlease try running command with --clean or check your internet connection"
       end
-      deploy_app(:put, "/api/v2/apps/#{app_id}.json", {})
+
+      deploy_app(:put, app_url, {})
     end
 
     desc 'migrate', 'Helps with the migration of a v1 app to v2'

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -192,7 +192,7 @@ module ZendeskAppsTools
 
       app_id = cache.fetch('app_id') || find_app_id
       app_url = "/api/v2/apps/#{app_id}.json"
-      unless /\d+/ =~ app_id.to_s && check_app_installed(app_url)
+      unless /\d+/ =~ app_id.to_s && app_exists?(app_id)
         say_error_and_exit "App id not found\nPlease try running command with --clean or check your internet connection"
       end
 

--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -17,6 +17,15 @@ module ZendeskAppsTools
       say_error_and_exit e.message
     end
 
+    def check_app_installed(url)
+      connection = get_connection
+      response = connection.send(:get) do |req|
+        req.url url
+      end
+
+      %w(200 201 202).include? response.status.to_s
+    end
+
     def install_app(poll_job, product_name, installation)
       connection = get_connection
       response = connection.post do |req|

--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -17,7 +17,8 @@ module ZendeskAppsTools
       say_error_and_exit e.message
     end
 
-    def check_app_installed(url)
+    def app_exists?(app_id)
+      url = "/api/v2/apps/#{app_id}.json"
       connection = get_connection
       response = connection.send(:get) do |req|
         req.url url


### PR DESCRIPTION
When the app ID provided in `.zat` is invalid and `zat update` is performed, the user gets a `RecordNotFound` (or `Internal Server Error` as reported in the Z1 ticket) error, which is unhelpful.

This PR adds a check to see if the app is installed, and bails early if otherwise.

@zendesk/sustaining @zendesk/vegemite 

### References

* https://support.zendesk.com/agent/tickets/3725488

### Risks

* Low: Might break private app updates via `zat update`