### PR TITLE
Fix build

### DIFF
--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -8,7 +8,7 @@ unless defined?(Cucumber)
   WebMock::API.stub_request(:post, 'https://app-account.zendesk.com/api/v2/apps/uploads.json').to_return(body: JSON.dump(id: '123'))
   WebMock::API.stub_request(:post, 'https://app-account.zendesk.com/api/apps.json').with(body: JSON.dump(name: 'John Test App', upload_id: '123')).to_return(body: JSON.dump(job_id: '987'))
   WebMock::API.stub_request(:get, 'https://app-account.zendesk.com/api/v2/apps/job_statuses/987').to_return(body: JSON.dump(status: 'working')).then.to_return(body: JSON.dump(status: 'completed', app_id: '55'))
-  WebMock::API.stub_request(:get, 'https://rubygems.org/api/v1/gems/zendesk_apps_tools.json').to_return(body: JSON.dump(status: 'working')).then.to_return(body: JSON.dump(name: 'zendesk_apps_tools', version: '2.1.1'))
+  WebMock::API.stub_request(:get, 'https://rubygems.org/api/v1/gems/zendesk_apps_tools.json').to_return(body: JSON.dump(status: 'working', version: '1.2.3')).then.to_return(body: JSON.dump(name: 'zendesk_apps_tools', version: '2.1.1'))
 
   WebMock.enable!
   WebMock.disable_net_connect!


### PR DESCRIPTION
`https://rubygems.org/api/v1/gems/zendesk_apps_tools.json` stub was missing `version` and this error was generated:

```
../home/travis/.rvm/rubies/ruby-2.0.0-p648/lib/ruby/site_ruby/2.0.0/rubygems/version.rb:209:in `initialize': Malformed version number string  (ArgumentError)
```

Probably has been working in the past based due to the random order of the specs and their stubs

RISK: low, fix a spec
