### PR TITLE
[AF-1067] Only return uniq product_codes

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -248,7 +248,7 @@ module ZendeskAppsTools
     end
 
     def product_codes(manifest)
-      manifest.location_options.collect{ |option| option.location.product_code }
+      manifest.location_options.collect{ |option| option.location.product_code }.uniq
     end
 
     def settings


### PR DESCRIPTION
When we execute `zat create` the app is installed multiple times(number of location times) per product.

This is caused due to a minor error in logic here: 
```
manifest.location_options.collect{ |option| option.location.product_code }
```

Consider an example where the manifest looks something like this:
```
"location": {
    "support": {
      "ticket_sidebar":"http://localhost:44000/parent",
      "modal": "http://localhost:44000/modal"
    }
  },
```

Now based on the above logic, we are transforming an array of 2 element like this:
`
[
{'location':'ticket_sidebar', 'product_code': 1, .... },
{'location':'modal', 'product_code': 1, .... }
]
` ==> `[1,1]`

The fix is just to return uniq values.

@zendesk/vegemite 

## Risk
[LOW] There is only one consumer for the `product_codes` function that is modified in this PR, that is `zat create` command. This command is already broken, which is being fixed in this PR.