### PR TITLE
[AF-1127] Switch locale endpoint

### DIFF
--- a/lib/zendesk_apps_tools/translate.rb
+++ b/lib/zendesk_apps_tools/translate.rb
@@ -11,7 +11,7 @@ module ZendeskAppsTools
     include ZendeskAppsTools::Common
 
     LOCALE_BASE_ENDPOINT = 'https://support.zendesk.com/api/v2/locales'
-    LOCALE_ENDPOINT = "#{LOCALE_BASE_ENDPOINT}/agent.json"
+    LOCALE_ENDPOINT = "#{LOCALE_BASE_ENDPOINT}/apps/admin.json"
 
     desc 'to_yml', 'Create Zendesk translation file from en.json'
     shared_options(except: [:clean])

--- a/spec/lib/zendesk_apps_tools/translate_spec.rb
+++ b/spec/lib/zendesk_apps_tools/translate_spec.rb
@@ -91,7 +91,7 @@ describe ZendeskAppsTools::Translate do
       expect(translate).to receive(:nest_translations_hash).once.and_return({})
       expect(translate).to receive(:write_json).once.with("translations/en.json", {})
 
-      stub_request(:get, "https://support.zendesk.com/api/v2/locales/agent.json").
+      stub_request(:get, "https://support.zendesk.com/api/v2/locales/apps/admin.json").
          to_return(:status => 200, :body => JSON.dump('locales' => [{ 'url' => 'https://support.zendesk.com/api/v2/locales/en.json', 'locale' => 'en' }]))
 
       stub_request(:get, "https://support.zendesk.com/api/v2/locales/en.json?include=translations&packages=app_my_app").


### PR DESCRIPTION
Switch local endpoint as suggested by the i18n team from `https://support.zendesk.com/api/v2/locales/agent.json` to `https://support.zendesk.com/api/v2/locales/apps/admin.json`.

@zendesk/vegemite @zendesk/i18n 