### PR TITLE
[OFFAPPS-1038] Update ZAT to support `zat new --scaffold` command option

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -118,7 +118,7 @@ module ZendeskAppsTools
         # clean when all apps are upgraded
         run_deprecation_checks unless options[:'unattended']
         say_status 'validate', 'OK'
-      else  
+      else
         errors.each do |e|
           say_status 'validate', e.to_s, :red
         end

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -69,6 +69,7 @@ module ZendeskAppsTools
 
       directory_options = {}
       if options[:scaffold]
+        # excludes everything but manifest.json
         directory_options = { exclude_pattern: /^((?!manifest.json).)*$/ }
       elsif @iframe_location != 'assets/iframe.html'
         directory_options = { exclude_pattern: /iframe.html/ }

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -54,13 +54,16 @@ module ZendeskAppsTools
       @app_name     = get_value_from_stdin("Enter a name for this new app:\n",
                                            error_msg: invalid.call('app name'))
 
-      @iframe_location = if options[:v1]
-                           '_legacy'
-                         else
-                           iframe_uri_text = 'Enter your iFrame URI or leave it blank to use'\
-                                             " a default local template page:\n"
-                           get_value_from_stdin(iframe_uri_text, allow_empty: true, default: 'assets/iframe.html')
-                         end
+      @iframe_location =
+        if options[:scaffold]
+          'assets/iframe.html'
+        elsif options[:v1]
+          '_legacy'
+        else
+          iframe_uri_text = 'Enter your iFrame URI or leave it blank to use'\
+                            " a default local template page:\n"
+          get_value_from_stdin(iframe_uri_text, allow_empty: true, default: 'assets/iframe.html')
+        end
 
       prompt_new_app_dir
 

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -67,19 +67,19 @@ module ZendeskAppsTools
 
       prompt_new_app_dir
 
-      directory_options = {}
+      directory_options =
       if options[:scaffold]
         # excludes everything but manifest.json
-        directory_options = { exclude_pattern: /^((?!manifest.json).)*$/ }
+        { exclude_pattern: /^((?!manifest.json).)*$/ }
       elsif @iframe_location != 'assets/iframe.html'
-        directory_options = { exclude_pattern: /iframe.html/ }
+        { exclude_pattern: /iframe.html/ }
+      else
+        {}
       end
 
       directory('app_template_iframe', @app_dir, directory_options)
 
-      if options[:scaffold]
-        download_scaffold(@app_dir)
-      end
+      download_scaffold(@app_dir) if options[:scaffold]
     end
 
     desc 'validate', 'Validate your app'
@@ -334,12 +334,12 @@ module ZendeskAppsTools
             if manifest_pattern.match?(filename)
               manifest_path = filename[0..-14]
             else
-              puts "Extracting #{filename}"
+              say_status 'info', "Extracting #{filename}"
               entry.extract("#{app_dir}/#{filename}")
             end
           end
         end
-        puts 'Moving manifest.json'
+        say_status 'info', 'Moving manifest.json'
         FileUtils.mv("#{app_dir}/manifest.json", "#{app_dir}/#{manifest_path}")
         say_status 'info', 'App created'
       rescue StandardError => e

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -70,18 +70,18 @@ module ZendeskAppsTools
       elsif @iframe_location != 'assets/iframe.html'
         directory_options = { exclude_pattern: /iframe.html/ }
       end
-        
+
       directory('app_template_iframe', @app_dir, directory_options)
 
       if options[:scaffold]
         require 'open-uri'
         require 'zip'
-        download = open("https://github.com/zendesk/app_scaffold/archive/offapps-migration.zip")
+        download = open("https://github.com/zendesk/app_scaffold/archive/master.zip")
         tmpDownloadName = "scaffold-download-temp.zip"
         IO.copy_stream(download, tmpDownloadName)
         Zip::File.open(tmpDownloadName) do |zip_file|
           zip_file.each do |entry|
-            filename = entry.name.sub("app_scaffold-offapps-migration/","")
+            filename = entry.name.sub("app_scaffold-master/",""))
             if filename != 'src/manifest.json'
               puts "Extracting #{filename}"
               entry.extract("#{@app_dir}/#{filename}")
@@ -152,7 +152,7 @@ module ZendeskAppsTools
     method_option :path, default: './', required: false, aliases: '-p'
     def clean
       require 'fileutils'
-      
+
       setup_path(options[:path])
 
       return unless File.exist?(Pathname.new(File.join(app_dir, 'tmp')).to_s)

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -74,23 +74,7 @@ module ZendeskAppsTools
       directory('app_template_iframe', @app_dir, directory_options)
 
       if options[:scaffold]
-        require 'open-uri'
-        require 'zip'
-        download = open("https://github.com/zendesk/app_scaffold/archive/master.zip")
-        tmpDownloadName = "scaffold-download-temp.zip"
-        IO.copy_stream(download, tmpDownloadName)
-        Zip::File.open(tmpDownloadName) do |zip_file|
-          zip_file.each do |entry|
-            filename = entry.name.sub("app_scaffold-master/",""))
-            if filename != 'src/manifest.json'
-              puts "Extracting #{filename}"
-              entry.extract("#{@app_dir}/#{filename}")
-            end
-          end
-        end
-        puts "Moving manifest.json"
-        FileUtils.mv("#{@app_dir}/manifest.json", "#{@app_dir}/src/")
-        File.delete(tmpDownloadName) if File.exist?(tmpDownloadName)
+        download_scaffold(@app_dir)
       end
     end
 
@@ -328,6 +312,26 @@ module ZendeskAppsTools
       rescue SocketError
         say_status 'warning', 'Unable to check for new versions of zendesk_apps_tools gem', :yellow
       end
+    end
+
+    def download_scaffold(app_dir)
+      require 'open-uri'
+      require 'zip'
+      download = open("https://github.com/zendesk/app_scaffold/archive/master.zip")
+      tmpDownloadName = "scaffold-download-temp.zip"
+      IO.copy_stream(download, tmpDownloadName)
+      Zip::File.open(tmpDownloadName) do |zip_file|
+        zip_file.each do |entry|
+          filename = entry.name.sub("app_scaffold-master/","")
+          if filename != 'src/manifest.json'
+            puts "Extracting #{filename}"
+            entry.extract("#{app_dir}/#{filename}")
+          end
+        end
+      end
+      puts "Movingg manifest.json"
+      FileUtils.mv("#{app_dir}/manifest.json", "#{app_dir}/src/")
+      File.delete(tmpDownloadName) if File.exist?(tmpDownloadName)
     end
   end
 end


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite
@zendesk/apps-migration 

### Tasks
- [x] Add new command option `zat new --scaffold` to create app using latest scaffold from [App Scaffold](https://github.com/zendesk/app_scaffold)
- [x] Make sure `zat migrate` is working after [OFFAPPS-1020](https://zendesk.atlassian.net/browse/OFFAPPS-1020)

### References
* JIRA: https://zendesk.atlassian.net/browse/OFFAPPS-1038

### Risks
* [medium] `zat new --scaffold` shouldn't affect existing command options `zat new`, `zat new --v1`, `zat new --iframe-only`
* [low] `zat migrate` should work as normal, it directly invoke the app_migrator executable, doesn't aware of the internal change of it.