### PR TITLE
Replace 2.4 method match? with 2.0 compatible method match

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (2.10.0)
+    zendesk_apps_tools (2.11.0)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -328,15 +328,14 @@ module ZendeskAppsTools
         require 'zip'
         download = open(scaffold_url)
         IO.copy_stream(download, tmp_download_name)
-        Zip::File.open(tmp_download_name) do |zip_file|
-          zip_file.each do |entry|
-            filename = entry.name.sub('app_scaffold-master/','')
-            if manifest_pattern.match?(filename)
-              manifest_path = filename[0..-14]
-            else
-              say_status 'info', "Extracting #{filename}"
-              entry.extract("#{app_dir}/#{filename}")
-            end
+        zip_file = Zip::File.open(tmp_download_name)
+        zip_file.each do |entry|
+          filename = entry.name.sub('app_scaffold-master/','')
+          if manifest_pattern.match(filename)
+            manifest_path = filename[0..-14]
+          else
+            say_status 'info', "Extracting #{filename}"
+            entry.extract("#{app_dir}/#{filename}")
           end
         end
         say_status 'info', 'Moving manifest.json'

--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '2.10.0'
+  VERSION = '2.11.0'
 end


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite
@zendesk/apps-migration 

### Tasks
- [x] Replace Ruby 2.4 method `match?` with `match` to support older Ruby versions (v2.0.0+)

### Risks
* [low] `zat new --scaffold` should not break