### PR TITLE
Improve the regular expression used to extract the template identifier from the path

### DIFF
--- a/lib/zendesk_apps_tools/theme.rb
+++ b/lib/zendesk_apps_tools/theme.rb
@@ -86,12 +86,14 @@ module ZendeskAppsTools
         listener.start
       end
 
+      IDENTIFIER_REGEX = /.*templates\/(?<identifier>.*)(?=\.hbs)/
+
       def generate_payload
         payload = {}
         templates = Dir.glob(theme_package_path('templates/*.hbs')) + Dir.glob(theme_package_path('templates/*/*.hbs'))
         templates_payload = {}
         templates.each do |template|
-          identifier = template.match(/(?<=templates\/).*(?=\.hbs)/).to_s
+          identifier = template.match(IDENTIFIER_REGEX)['identifier'].to_s
           templates_payload[identifier] = File.read(template)
         end
         payload['templates'] = templates_payload


### PR DESCRIPTION
It might happen that the local theme is in a directory called e.g.: `cph_with_alternate_templates`. In such case, the former regex would have captured `templates/footer` instead of just `footer`. The proposed regex takes a greedy approach and matches the path after the last occurrence of `templates/`.

@zendesk/guide-growth 