### PR TITLE
Add Validation for Account Subdomain & Email

### DIFF
--- a/lib/zendesk_apps_tools/api_connection.rb
+++ b/lib/zendesk_apps_tools/api_connection.rb
@@ -1,10 +1,9 @@
 module ZendeskAppsTools
   module APIConnection
+    DEFAULT_URL_TEMPLATE = 'https://%s.zendesk.com/'
     # taken from zendesk_console/lib/vars.rb
     SUBDOMAIN_VALIDATION_PATTERN = /\A[a-z0-9][a-z0-9\-]{1,}[a-z0-9]\z/
-    ZENDESK_URL_VALIDATION_PATTERN = /\A(http|https):\/\/[a-z0-9]+(([\.]|[\-]{1,2})[a-z0-9]+)*\.([a-z]{2,16}|[0-9]{1,3})((:[0-9]{1,5})?(\/?|\/.*))?\z/ix
-    DEFAULT_URL_TEMPLATE = 'https://%s.zendesk.com/'
-
+    ZENDESK_URL_VALIDATION_PATTERN = /\A(https?):\/\/[a-z0-9]+(([\.]|[\-]{1,2})[a-z0-9]+)*\.([a-z]{2,16}|[0-9]{1,3})((:[0-9]{1,5})?(\/?|\/.*))?\z/ix
     # Ruby versions compatible
     EMAIL_REGEX  = URI::MailTo.constants.include?(:EMAIL_REGEXP) ? URI::MailTo::EMAIL_REGEXP : URI::MailTo::MAILTO_REGEXP
 
@@ -46,15 +45,15 @@ module ZendeskAppsTools
     end
 
     def valid_full_url?
-      ZENDESK_URL_VALIDATION_PATTERN.match? @subdomain
+      !!ZENDESK_URL_VALIDATION_PATTERN.match(@subdomain)
     end
 
     def valid_subdomain?
-      SUBDOMAIN_VALIDATION_PATTERN.match? @subdomain
+      !!SUBDOMAIN_VALIDATION_PATTERN.match(@subdomain)
     end
 
     def valid_email?
-      EMAIL_REGEX.match? @username
+      !!EMAIL_REGEX.match(@username)
     end
   end
 end

--- a/lib/zendesk_apps_tools/api_connection.rb
+++ b/lib/zendesk_apps_tools/api_connection.rb
@@ -1,19 +1,18 @@
 module ZendeskAppsTools
   module APIConnection
     DEFAULT_URL_TEMPLATE = 'https://%s.zendesk.com/'
-    # taken from zendesk_console/lib/vars.rb
-    SUBDOMAIN_VALIDATION_PATTERN = /\A[a-z0-9][a-z0-9\-]{1,}[a-z0-9]\z/
-    ZENDESK_URL_VALIDATION_PATTERN = /\A(https?):\/\/[a-z0-9]+(([\.]|[\-]{1,2})[a-z0-9]+)*\.([a-z]{2,16}|[0-9]{1,3})((:[0-9]{1,5})?(\/?|\/.*))?\z/ix
-    # Ruby versions compatible
-    EMAIL_REGEX  = URI::MailTo.constants.include?(:EMAIL_REGEXP) ? URI::MailTo::EMAIL_REGEXP : URI::MailTo::MAILTO_REGEXP
+    # taken from zendesk/lib/vars.rb
+    SUBDOMAIN_VALIDATION_PATTERN = /^[a-z0-9][a-z0-9\-]{1,}[a-z0-9]$/i
+    ZENDESK_URL_VALIDATION_PATTERN = /^(https?):\/\/[a-z0-9]+(([\.]|[\-]{1,2})[a-z0-9]+)*\.([a-z]{2,16}|[0-9]{1,3})((:[0-9]{1,5})?(\/?|\/.*))?$/ix
+    EMAIL_REGEX  = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i
 
     EMAIL_ERROR_MSG = 'Please enter a valid email address.'
-    PROMPT_FOR_URL  = 'Enter your Zendesk subdomain or FULL url (including protocol):'
+    PROMPT_FOR_URL  = 'Enter your Zendesk subdomain or full URL (including protocol):'
     URL_ERROR_MSG   = [
-      'URL error. Example URL: https://mysubdomain.zendesk.com ',
+      'URL error. Example URL: https://mysubdomain.zendesk.com',
       'If you are using FULL url, please follow the url as shown above.',
       'If you are using URL subdomain, please enter the equivalent of \'mysubdomain\' of the url above.'
-    ].join("\n")
+    ].join('\n')
 
     def prepare_api_auth
       @subdomain ||= cache.fetch('subdomain') || get_value_from_stdin(PROMPT_FOR_URL)

--- a/lib/zendesk_apps_tools/api_connection.rb
+++ b/lib/zendesk_apps_tools/api_connection.rb
@@ -10,8 +10,8 @@ module ZendeskAppsTools
     PROMPT_FOR_URL  = 'Enter your Zendesk subdomain or full URL (including protocol):'
     URL_ERROR_MSG   = [
       'URL error. Example URL: https://mysubdomain.zendesk.com',
-      'If you are using FULL url, please follow the url as shown above.',
-      'If you are using URL subdomain, please enter the equivalent of \'mysubdomain\' of the url above.'
+      'If you are using a full URL, follow the url as shown above.',
+      'If you are using a subdomain, ensure that it contains only valid characters (a-z, A-Z, 0-9, and hyphens).'
     ].join('\n')
 
     def prepare_api_auth

--- a/lib/zendesk_apps_tools/api_connection.rb
+++ b/lib/zendesk_apps_tools/api_connection.rb
@@ -1,11 +1,21 @@
 module ZendeskAppsTools
   module APIConnection
-    FULL_URL     = /https?:\/\//
+    SUBDOMAIN    = /\A[a-z0-9][a-z0-9\-]{1,}[a-z0-9]\z/
+    FULL_URL     = Regexp::new(/https?:\/\//.source + SUBDOMAIN.source + /\.zendesk\.com/.source)
     URL_TEMPLATE = 'https://%s.zendesk.com/'
+    EMAIL_REGEX  = URI::MailTo::EMAIL_REGEXP
+
+    EMAIL_ERROR_MSG     = 'Please enter a valid email address'
+    SUBDOMAIN_ERROR_MSG = 'Make sure you entered the right subdomain name '\
+      '(e.g. if account url is https://mysubdomain.zendesk.com, then enter mysubdomain).'
 
     def prepare_api_auth
-      @subdomain ||= cache.fetch('subdomain') || get_value_from_stdin('Enter your Zendesk subdomain or full Zendesk URL:')
+      @subdomain ||= cache.fetch('subdomain') || get_value_from_stdin('Enter your Zendesk subdomain:')
+      say_error_and_exit SUBDOMAIN_ERROR_MSG unless @subdomain =~ SUBDOMAIN
+
       @username  ||= cache.fetch('username', @subdomain) || get_value_from_stdin('Enter your username:')
+      say_error_and_exit EMAIL_ERROR_MSG unless @username =~ EMAIL_REGEX
+
       @password  ||= cache.fetch('password', @subdomain) || get_password_from_stdin('Enter your password:')
 
       cache.save 'subdomain' => @subdomain, 'username' => @username

--- a/lib/zendesk_apps_tools/api_connection.rb
+++ b/lib/zendesk_apps_tools/api_connection.rb
@@ -3,7 +3,9 @@ module ZendeskAppsTools
     SUBDOMAIN    = /\A[a-z0-9][a-z0-9\-]{1,}[a-z0-9]\z/
     FULL_URL     = Regexp::new(/https?:\/\//.source + SUBDOMAIN.source + /\.zendesk\.com/.source)
     URL_TEMPLATE = 'https://%s.zendesk.com/'
-    EMAIL_REGEX  = URI::MailTo::EMAIL_REGEXP
+
+    # For Ruby 2 and 2.1 compatible
+    EMAIL_REGEX  = URI::MailTo.constants.include?(:EMAIL_REGEXP) ? URI::MailTo::EMAIL_REGEXP : URI::MailTo::MAILTO_REGEXP
 
     EMAIL_ERROR_MSG     = 'Please enter a valid email address'
     SUBDOMAIN_ERROR_MSG = 'Make sure you entered the right subdomain name '\

--- a/lib/zendesk_apps_tools/api_connection.rb
+++ b/lib/zendesk_apps_tools/api_connection.rb
@@ -1,22 +1,27 @@
 module ZendeskAppsTools
   module APIConnection
-    SUBDOMAIN    = /\A[a-z0-9][a-z0-9\-]{1,}[a-z0-9]\z/
-    FULL_URL     = Regexp::new(/https?:\/\//.source + SUBDOMAIN.source + /\.zendesk\.com/.source)
-    URL_TEMPLATE = 'https://%s.zendesk.com/'
+    # taken from zendesk_console/lib/vars.rb
+    SUBDOMAIN_VALIDATION_PATTERN = /\A[a-z0-9][a-z0-9\-]{1,}[a-z0-9]\z/
+    ZENDESK_URL_VALIDATION_PATTERN = /\A(http|https):\/\/[a-z0-9]+(([\.]|[\-]{1,2})[a-z0-9]+)*\.([a-z]{2,16}|[0-9]{1,3})((:[0-9]{1,5})?(\/?|\/.*))?\z/ix
+    DEFAULT_URL_TEMPLATE = 'https://%s.zendesk.com/'
 
-    # For Ruby 2 and 2.1 compatible
+    # Ruby versions compatible
     EMAIL_REGEX  = URI::MailTo.constants.include?(:EMAIL_REGEXP) ? URI::MailTo::EMAIL_REGEXP : URI::MailTo::MAILTO_REGEXP
 
-    EMAIL_ERROR_MSG     = 'Please enter a valid email address'
-    SUBDOMAIN_ERROR_MSG = 'Make sure you entered the right subdomain name '\
-      '(e.g. if account url is https://mysubdomain.zendesk.com, then enter mysubdomain).'
+    EMAIL_ERROR_MSG = 'Please enter a valid email address.'
+    PROMPT_FOR_URL  = 'Enter your Zendesk subdomain or FULL url (including protocol):'
+    URL_ERROR_MSG   = [
+      'URL error. Example URL: https://mysubdomain.zendesk.com ',
+      'If you are using FULL url, please follow the url as shown above.',
+      'If you are using URL subdomain, please enter the equivalent of \'mysubdomain\' of the url above.'
+    ].join("\n")
 
     def prepare_api_auth
-      @subdomain ||= cache.fetch('subdomain') || get_value_from_stdin('Enter your Zendesk subdomain:')
-      say_error_and_exit SUBDOMAIN_ERROR_MSG unless @subdomain =~ SUBDOMAIN
+      @subdomain ||= cache.fetch('subdomain') || get_value_from_stdin(PROMPT_FOR_URL)
+      say_error_and_exit URL_ERROR_MSG unless valid_subdomain? || valid_full_url?
 
       @username  ||= cache.fetch('username', @subdomain) || get_value_from_stdin('Enter your username:')
-      say_error_and_exit EMAIL_ERROR_MSG unless @username =~ EMAIL_REGEX
+      say_error_and_exit EMAIL_ERROR_MSG unless valid_email?
 
       @password  ||= cache.fetch('password', @subdomain) || get_password_from_stdin('Enter your password:')
 
@@ -37,11 +42,19 @@ module ZendeskAppsTools
     private
 
     def full_url
-      if FULL_URL =~ @subdomain
-        @subdomain
-      else
-        URL_TEMPLATE % @subdomain
-      end
+      valid_full_url? ? @subdomain : (DEFAULT_URL_TEMPLATE % @subdomain)
+    end
+
+    def valid_full_url?
+      ZENDESK_URL_VALIDATION_PATTERN.match? @subdomain
+    end
+
+    def valid_subdomain?
+      SUBDOMAIN_VALIDATION_PATTERN.match? @subdomain
+    end
+
+    def valid_email?
+      EMAIL_REGEX.match? @username
     end
   end
 end

--- a/spec/lib/zendesk_apps_tools/api_connection_spec.rb
+++ b/spec/lib/zendesk_apps_tools/api_connection_spec.rb
@@ -79,37 +79,36 @@ describe ZendeskAppsTools::APIConnection do
           }
           @cache = zat_cache
         end
-
-        # mocking say_error_and_exit in ZendeskAppsTools::Common::ClassMethods
-        def say_error_and_exit(error_message)
-          raise SystemExit.new(error_message)
-        end
-      end
-    end
-
-    define_method(:method_execution) do |subject_instance|
-      begin
-        subject_instance.prepare_api_auth
-      rescue SystemExit => e
-        e.message
       end
     end
 
     context 'invalid subdomain' do
       it 'errors and exit' do
-        expect(method_execution(subject_class.new('bad!subdomain'))).to eq(url_error_message)
+        subject = subject_class.new('bad!subdomain')
+
+        expect(subject).to receive(:say_error_and_exit).with(url_error_message) { exit }
+
+        expect { subject.prepare_api_auth }.to raise_error(SystemExit)
       end
     end
 
     context 'invalid full url' do
       it 'errors and exit' do
-        expect(method_execution(subject_class.new('www.keith.com'))).to eq(url_error_message)
+        subject = subject_class.new('www.keith.com')
+
+        expect(subject).to receive(:say_error_and_exit).with(url_error_message) { exit }
+
+        expect { subject.prepare_api_auth }.to raise_error(SystemExit)
       end
     end
 
     context 'with invalid email format' do
       it 'errors and exit' do
-        expect(method_execution(subject_class.new('subdomain', 'bad-email'))).to eq(email_error_message)
+        subject = subject_class.new('subdomain', 'bad-email')
+
+        expect(subject).to receive(:say_error_and_exit).with(email_error_message) { exit }
+
+        expect { subject.prepare_api_auth }.to raise_error(SystemExit)
       end
     end
   end

--- a/spec/lib/zendesk_apps_tools/api_connection_spec.rb
+++ b/spec/lib/zendesk_apps_tools/api_connection_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+require 'api_connection'
+require 'common'
+
+describe ZendeskAppsTools::APIConnection do
+  let(:subdomain_validation_pattern) { ZendeskAppsTools::APIConnection::SUBDOMAIN_VALIDATION_PATTERN }
+  let(:url_validation_pattern)       { ZendeskAppsTools::APIConnection::ZENDESK_URL_VALIDATION_PATTERN }
+  let(:default_url_template)         { ZendeskAppsTools::APIConnection::DEFAULT_URL_TEMPLATE }
+
+  describe 'CONSTANTS' do
+    describe 'DEFAULT_URL_TEMPLATE' do
+      context '% subdomain (used in private method full_url)' do
+        it 'replaces %s with subdomain in template' do
+          user_input_subdomain = 'my-subdomain'
+          expect(default_url_template % user_input_subdomain).to eq("https://my-subdomain.zendesk.com/")
+        end
+      end
+    end
+
+    describe 'SUBDOMAIN_VALIDATION_PATTERN' do
+      context 'valid_subdomain? (a private method)' do
+        define_method(:valid_subdomain?) { |subdomain| !!subdomain_validation_pattern.match(subdomain) }
+
+        it 'returns false if subdomain is NOT in valid format' do
+          expect(valid_subdomain?('sub.domain')).to eq(false)
+          expect(valid_subdomain?('sub!domain')).to eq(false)
+          expect(valid_subdomain?('sub~domain')).to eq(false)
+          expect(valid_subdomain?('sub_domain')).to eq(false)
+          expect(valid_subdomain?('SUBDOMAIN')).to eq(false)
+          expect(valid_subdomain?('subDomain')).to eq(false)
+        end
+
+        it 'returns true if subdomain is in valid format' do
+          expect(valid_subdomain?('subdomain')).to eq(true)
+          expect(valid_subdomain?('sub-domain')).to eq(true)
+        end
+      end
+    end
+
+    describe 'ZENDESK_URL_VALIDATION_PATTERN' do
+      context 'valid_full_url? (a private method)' do
+        define_method(:valid_full_url?) { |subdomain|  !!url_validation_pattern.match(subdomain) }
+
+        context 'with regular zendesk urls' do
+          it 'returns false when subdomain does not match full url pattern' do
+            expect(valid_full_url?('www.subdomain.com')).to eq(false)
+            expect(valid_full_url?('subdomain.com')).to eq(false)
+          end
+
+          it 'returns true when subdomain does match full url pattern' do
+            expect(valid_full_url?('https://subdomain.zendesk.com')).to eq(true)
+            expect(valid_full_url?('https://my-subdomain.zendesk-staging.com')).to eq(true)
+          end
+        end
+
+        context 'with host map urls' do
+          it 'returns true when subdomain of customized urls matches full url pattern' do
+            expect(valid_full_url?('https://subdomain.com')).to eq(true)
+            expect(valid_full_url?('https://www.subdomain.com')).to eq(true)
+            expect(valid_full_url?('https://subdomain.au')).to eq(true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/zendesk_apps_tools/cache_spec.rb
+++ b/spec/lib/zendesk_apps_tools/cache_spec.rb
@@ -12,7 +12,7 @@ describe ZendeskAppsTools::Cache do
 
     before do
       content = JSON.dump(subdomain: 'under-the-domain', username: 'Roger@something.com', app_id: 12)
-      File.write(File.join(tmpdir, '.zat'), content, mode: 'w')
+      File.write(zat_file, content, mode: 'w')
     end
 
     after do

--- a/spec/lib/zendesk_apps_tools/cache_spec.rb
+++ b/spec/lib/zendesk_apps_tools/cache_spec.rb
@@ -10,7 +10,7 @@ describe ZendeskAppsTools::Cache do
     let(:tmpdir) { Dir.mktmpdir }
 
     before do
-      content = JSON.dump(subdomain: 'under-the-domain', username: 'Roger', app_id: 12)
+      content = JSON.dump(subdomain: 'under-the-domain', username: 'Roger@something.com', app_id: 12)
       File.write(File.join(tmpdir, '.zat'), content, mode: 'w')
     end
 
@@ -20,7 +20,7 @@ describe ZendeskAppsTools::Cache do
 
     describe '#fetch' do
       it 'reads data from the cache' do
-        expect(cache.fetch('username')).to eq 'Roger'
+        expect(cache.fetch('username')).to eq 'Roger@something.com'
       end
 
       context 'with a global cache' do

--- a/spec/lib/zendesk_apps_tools/command_spec.rb
+++ b/spec/lib/zendesk_apps_tools/command_spec.rb
@@ -61,12 +61,16 @@ describe ZendeskAppsTools::Command do
         allow(@command.cache).to receive(:fetch).with('app_id').and_return('987')
 
         stub_request(:post, PREFIX + '/api/apps.json')
-          .with(body: JSON.generate(name: 'abc', upload_id: '123'),
-                headers: AUTHORIZATION_HEADER)
+          .with(
+            body: JSON.generate(name: 'abc', upload_id: '123'),
+            headers: AUTHORIZATION_HEADER
+          )
 
         stub_request(:post, PREFIX + '/api/support/apps/installations.json')
-          .with(body: JSON.generate(app_id: '987', settings: { name: 'abc' }),
-                headers: { 'Authorization' => 'Basic dXNlcm5hbWVAc29tZXRoaW5nLmNvbTpwYXNzd29yZA==', 'Content-Type' => 'application/json' })
+          .with(
+            body: JSON.generate(app_id: '987', settings: { name: 'abc' }),
+            headers: AUTHORIZATION_HEADER.merge({ 'Content-Type' => 'application/json' })
+          )
 
         @command.create
       end
@@ -82,12 +86,16 @@ describe ZendeskAppsTools::Command do
         expect(@command).to receive(:get_value_from_stdin) { 'abc' }
 
         stub_request(:post, PREFIX + '/api/apps.json')
-          .with(body: JSON.generate(name: 'abc', upload_id: '123'),
-                headers: AUTHORIZATION_HEADER)
+          .with(
+            body: JSON.generate(name: 'abc', upload_id: '123'),
+            headers: AUTHORIZATION_HEADER
+          )
 
         stub_request(:post, PREFIX + '/api/support/apps/installations.json')
-          .with(body: JSON.generate(app_id: nil, settings: { name: 'abc' }),
-                headers: { 'Authorization' => 'Basic dXNlcm5hbWVAc29tZXRoaW5nLmNvbTpwYXNzd29yZA==', 'Content-Type' => 'application/json' })
+          .with(
+            body: JSON.generate(app_id: nil, settings: { name: 'abc' }),
+            headers: AUTHORIZATION_HEADER.merge({ 'Content-Type' => 'application/json' })
+          )
 
         @command.create
       end

--- a/spec/lib/zendesk_apps_tools/command_spec.rb
+++ b/spec/lib/zendesk_apps_tools/command_spec.rb
@@ -6,10 +6,11 @@ require 'zip'
 
 describe ZendeskAppsTools::Command do
   PREFIX = 'https://subdomain.zendesk.com'
+  AUTHORIZATION_HEADER = { 'Authorization' => 'Basic dXNlcm5hbWVAc29tZXRoaW5nLmNvbTpwYXNzd29yZA==' }
 
   before do
     @command = ZendeskAppsTools::Command.new
-    @command.instance_variable_set(:@username, 'username')
+    @command.instance_variable_set(:@username, 'username@something.com')
     @command.instance_variable_set(:@password, 'password')
     @command.instance_variable_set(:@subdomain, 'subdomain')
     @command.instance_variable_set(:@app_id, '123')
@@ -29,7 +30,7 @@ describe ZendeskAppsTools::Command do
         allow(Faraday::UploadIO).to receive(:new)
 
         stub_request(:post, PREFIX + '/api/v2/apps/uploads.json')
-          .with(headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
+          .with(headers: AUTHORIZATION_HEADER)
           .to_return(body: '{ "id": 123 }')
 
         expect(@command.upload('nah')).to eq(123)
@@ -42,7 +43,7 @@ describe ZendeskAppsTools::Command do
         expect(Faraday::UploadIO).to receive(:new).with('app.zip', 'application/zip').and_return(nil)
 
         stub_request(:post, PREFIX + '/api/v2/apps/uploads.json')
-          .with(headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
+          .with(headers: AUTHORIZATION_HEADER)
           .to_return(body: '{ "id": 123 }')
 
         expect(@command.upload('nah')).to eq(123)
@@ -61,11 +62,11 @@ describe ZendeskAppsTools::Command do
 
         stub_request(:post, PREFIX + '/api/apps.json')
           .with(body: JSON.generate(name: 'abc', upload_id: '123'),
-                headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
+                headers: AUTHORIZATION_HEADER)
 
         stub_request(:post, PREFIX + '/api/support/apps/installations.json')
           .with(body: JSON.generate(app_id: '987', settings: { name: 'abc' }),
-                headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=', 'Content-Type' => 'application/json' })
+                headers: { 'Authorization' => 'Basic dXNlcm5hbWVAc29tZXRoaW5nLmNvbTpwYXNzd29yZA==', 'Content-Type' => 'application/json' })
 
         @command.create
       end
@@ -82,11 +83,11 @@ describe ZendeskAppsTools::Command do
 
         stub_request(:post, PREFIX + '/api/apps.json')
           .with(body: JSON.generate(name: 'abc', upload_id: '123'),
-                headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
+                headers: AUTHORIZATION_HEADER)
 
         stub_request(:post, PREFIX + '/api/support/apps/installations.json')
           .with(body: JSON.generate(app_id: nil, settings: { name: 'abc' }),
-                headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=', 'Content-Type' => 'application/json' })
+                headers: { 'Authorization' => 'Basic dXNlcm5hbWVAc29tZXRoaW5nLmNvbTpwYXNzd29yZA==', 'Content-Type' => 'application/json' })
 
         @command.create
       end
@@ -101,9 +102,9 @@ describe ZendeskAppsTools::Command do
         expect(@command.cache).to receive(:fetch).with('app_id').and_return(456)
 
         stub_request(:put, PREFIX + '/api/v2/apps/456.json')
-          .with(headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
+          .with(headers: AUTHORIZATION_HEADER)
         stub_request(:get, PREFIX + '/api/v2/apps/456.json')
-          .with(headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
+          .with(headers: AUTHORIZATION_HEADER)
           .to_return(:status => 200)
 
         @command.update
@@ -112,7 +113,7 @@ describe ZendeskAppsTools::Command do
       context 'when app id is in cache and is invalid' do
         it 'displays error message and exits' do
           stub_request(:get, PREFIX + '/api/v2/apps/333.json')
-            .with(headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
+            .with(headers: AUTHORIZATION_HEADER)
             .to_return(:status => 404)
 
           expect(@command.cache).to receive(:fetch).with('app_id').and_return(333)
@@ -142,7 +143,7 @@ describe ZendeskAppsTools::Command do
 
       it 'cannot find the app id' do
         stub_request(:get, PREFIX + '/api/apps.json')
-          .with(headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
+          .with(headers: AUTHORIZATION_HEADER)
           .to_return(body: '')
         expect(@command).to receive(:say_error).with(/^The app was not found./)
         expect { @command.update }.to raise_error(SystemExit)
@@ -150,10 +151,10 @@ describe ZendeskAppsTools::Command do
 
       it 'finds the app id' do
         stub_request(:get, PREFIX + '/api/apps.json')
-          .with(headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
+          .with(headers: AUTHORIZATION_HEADER)
           .to_return(body: JSON.generate(apps))
         stub_request(:get, PREFIX + '/api/v2/apps/125.json')
-          .with(headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
+          .with(headers: AUTHORIZATION_HEADER)
           .to_return(:status => 200)
 
         expect(@command.send(:find_app_id)).to eq(125)


### PR DESCRIPTION
## **AF-1258 / Add validation for Account Subdomain and Email**
cc: @zendesk/vegemite 

### Description
Previously when a developer tries to `zat create` or `zat update`, the CLI prompts developers to input account subdomain and email (as username). 

There was no validation around these input, resulting in ZAT trying to access invalid urls such as
`myzendesksubdomain.zendesk.com.zendesk.com`

### Implementation Notes
1. Put Validation around subdomains, full urls and email (username) using regex. Use ruby method `!!foo.match(bar)` to determine if they match. `.match?` is only available for newer versions of Ruby.

2. Regular Expression for Email is **explicitly** defined instead of using `URI::MailTo::EMAIL_REGEXP || URI::MailTo::MAILTO_REGEXP` as `URI::MailTo::MAILTO_REGEXP` is not entirely accurate.

3. Regular Expression for full url and subdomain is taken from `zendesk/lib/vars.rb` to implement some sense of consistency. full urls covers customized host map urls.

4. Write Test for the Constants(with regexes) and test how they are used.

### Tasks
- [x] add spec for prepare_api_auth
- [x] think about .zendesk-staging.com
- [x] allow developers to use full and host map urls as well
- [x] update screenshots
- [x] include regex validations screenshots for emails, urls and subdomains

### Updated Screenshots (Results)
<details>
<summary>When an invalid subdomain is entered </summary>
<em>Error Message for Invalid Subdomain / URL</em>
<img width="811" alt="incorrect subdomain" src="https://user-images.githubusercontent.com/17760485/48926803-2b0e8380-ef25-11e8-9eba-b4e268af3233.png">
</details>

<details>
<summary>When a correct "subdomain" is entered </summary>
<em>We get to Email Prompt. "subdomain" also takes in a full url (with protocol) for backwards compatibility.</em>
<img width="810" alt="screen shot 2018-11-23 at 1 37 59 pm" src="https://user-images.githubusercontent.com/17760485/48926818-3eb9ea00-ef25-11e8-9234-76cab58b459e.png">
<img width="807" alt="screen shot 2018-11-23 at 1 38 26 pm" src="https://user-images.githubusercontent.com/17760485/48926820-3eb9ea00-ef25-11e8-9220-a335d025ff00.png">
<img width="810" alt="screen shot 2018-11-23 at 1 41 35 pm" src="https://user-images.githubusercontent.com/17760485/48926855-89d3fd00-ef25-11e8-9c90-dca059e3a92f.png">
</details>

<details>
<summary>When an invalid email is entered</summary>
<em>Error Message for Invalid Email</em>
<img width="812" alt="screen shot 2018-11-23 at 1 40 47 pm" src="https://user-images.githubusercontent.com/17760485/48926838-6c9f2e80-ef25-11e8-94b9-06a935f26b65.png">
</details>

<details>
<summary>When all is entered correctly</summary>
<em>We get to Password Prompt</em>
<img width="811" alt="screen shot 2018-11-23 at 1 43 04 pm" src="https://user-images.githubusercontent.com/17760485/48926879-bf78e600-ef25-11e8-9751-b70855d25bf7.png">
</details>

### Regex Validation Screenshots
<details>
<summary>Subdomain</summary>
SUBDOMAIN_VALIDATION_PATTERN = /^[a-z0-9][a-z0-9\-]{1,}[a-z0-9]$/i , where we're actively ignoring spaces before and after subdomain with `^` and `$`. Case Insensitive. 
<img width="995" alt="screen shot 2018-11-23 at 1 51 15 pm" src="https://user-images.githubusercontent.com/17760485/48927040-f4396d00-ef26-11e8-86b8-89ab7a44981a.png">
</details>

<details>
<summary>Full URLs</summary>
ZENDESK_URL_VALIDATION_PATTERN = /^(https?):\/\/[a-z0-9]+(([\.]|[\-]{1,2})[a-z0-9]+)*\.([a-z]{2,16}|[0-9]{1,3})((:[0-9]{1,5})?(\/?|\/.*))?$/ix , where we're actively ignoring spaces before and after subdomain with `^` and `$`. Case Insensitive and extended.
<img width="995" alt="screen shot 2018-11-23 at 2 03 23 pm" src="https://user-images.githubusercontent.com/17760485/48927267-9c036a80-ef28-11e8-8d2b-eb41a5c20154.png">
</details>

<details>
<summary>Email (Username)</summary>
EMAIL_REGEX  = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i , where we're actively ignoring spaces before and after subdomain with `^` and `$`. Case Insensitive.
<img width="996" alt="screen shot 2018-11-23 at 2 07 30 pm" src="https://user-images.githubusercontent.com/17760485/48927332-29df5580-ef29-11e8-9d5a-b59583596666.png">
</details>

### References
[Jira Ticket](https://zendesk.atlassian.net/browse/AF-1258)
[Testing Modules in Rspec with include or exclude](https://stackoverflow.com/questions/1542945/testing-modules-in-rspec)
[Including vs Excluding Module](https://medium.com/@leo_hetsch/ruby-modules-include-vs-prepend-vs-extend-f09837a5b073)
[Testing Modules Ruby Modules with Rspec](https://mixandgo.com/learn/how-to-test-ruby-modules-with-rspec)

[Rubular for Regex](http://rubular.com/)
[subdomain & URL regex](https://github.com/zendesk/zendesk/blob/1bf56e2c9e4bb0de185faae1daab9bdabb5e475b/lib/vars.rb#L28)
[email (username) regex](https://awesoham.wordpress.com/2013/10/02/a-simple-regex-for-rails-email-validation/)

### Risks
[low] - developers may not be able to do 'zat create' or 'update' as subdomain and username are validated with regular expressions
