### PR TITLE
Refactor find_app_id in ZendeskAppsTools::Deploy

### DIFF
--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -100,10 +100,10 @@ module ZendeskAppsTools
     end
 
     def check_job(job_id)
-      check_job_connection = connection
+      http_client = connection
 
       loop do
-        response = check_job_connection.get("/api/v2/apps/job_statuses/#{job_id}")
+        response = http_client.get("/api/v2/apps/job_statuses/#{job_id}")
         info     = json_or_die(response.body)
         status   = info['status']
 

--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -69,9 +69,10 @@ module ZendeskAppsTools
 
       all_apps_json = connection.get('/api/apps.json').body
 
-      app = unless all_apps_json.empty?
-        json_or_die(all_apps_json)['apps'].find { |app| app['name'] == app_name }
-      end
+      app =
+        unless all_apps_json.empty?
+          json_or_die(all_apps_json)['apps'].find { |app| app['name'] == app_name }
+        end
 
       unless app
         say_error_and_exit(

--- a/spec/lib/zendesk_apps_tools/cache_spec.rb
+++ b/spec/lib/zendesk_apps_tools/cache_spec.rb
@@ -6,12 +6,13 @@ require 'fileutils'
 
 describe ZendeskAppsTools::Cache do
   context 'with a local cache file' do
-    let(:cache) { ZendeskAppsTools::Cache.new(path: tmpdir) }
-    let(:tmpdir) { Dir.mktmpdir }
+    let(:tmpdir)   { Dir.mktmpdir }
+    let(:cache)    { ZendeskAppsTools::Cache.new(path: tmpdir) }
+    let(:zat_file) { File.join(tmpdir, '.zat') }
 
     before do
       content = JSON.dump(subdomain: 'under-the-domain', username: 'Roger', app_id: 12)
-      File.write(File.join(tmpdir, '.zat'), content, mode: 'w')
+      File.write(zat_file, content, mode: 'w')
     end
 
     after do
@@ -45,20 +46,20 @@ describe ZendeskAppsTools::Cache do
     describe '#save' do
       it 'works' do
         cache.save(other_key: 'value')
-        expect(JSON.parse(File.read(File.join(tmpdir, '.zat')))['other_key']).to eq 'value'
+        expect(JSON.parse(File.read(zat_file))['other_key']).to eq 'value'
       end
     end
 
     describe '#clear' do
       it 'does nothing by default' do
         cache.clear
-        expect(File.exist?(File.join(tmpdir, '.zat'))).to be_truthy
+        expect(File.exist?(zat_file)).to be_truthy
       end
 
       it 'works' do
         cache = ZendeskAppsTools::Cache.new(path: tmpdir, clean: true)
         cache.clear
-        expect(File.exist?(File.join(tmpdir, '.zat'))).to be_falsey
+        expect(File.exist?(zat_file)).to be_falsey
       end
     end
   end

--- a/spec/lib/zendesk_apps_tools/command_spec.rb
+++ b/spec/lib/zendesk_apps_tools/command_spec.rb
@@ -144,7 +144,10 @@ describe ZendeskAppsTools::Command do
         stub_request(:get, PREFIX + '/api/apps.json')
           .with(headers: { 'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' })
           .to_return(body: '')
-        expect(@command).to receive(:say_error).with(/^The app was not found./)
+        expect(@command).to receive(:say_error).with(
+          "App not found. " \
+          "Please verify that your credentials, subdomain, and app name are correct."
+        )
         expect { @command.update }.to raise_error(SystemExit)
       end
 

--- a/spec/lib/zendesk_apps_tools/deploy_spec.rb
+++ b/spec/lib/zendesk_apps_tools/deploy_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+require 'zendesk_apps_tools/deploy'
+require 'json'
+
+describe ZendeskAppsTools::Deploy do
+  let(:mock_response) do
+    Class.new do
+      attr_reader :body
+      def initialize(json_body)
+        @body = json_body
+      end
+
+      def get(uri)
+        self
+      end
+    end
+  end
+
+  let(:subject_class) do
+    Class.new do
+      include ZendeskAppsTools::Deploy
+      attr_reader :get_connection
+
+      def initialize(get_response)
+        @get_connection = get_response
+      end
+
+      def connection(multipart = nil)
+        get_connection
+      end
+
+      def say_status(command, text)
+      end
+
+      def get_value_from_stdin(text)
+        'app_2'
+      end
+
+      def say(message, color = nil)
+      end
+    end
+  end
+
+  let(:response_with_apps) {
+    {
+      'apps'=> [
+        {'name'=> 'app_1', 'id'=> 1},
+        {'name'=> 'app_2', 'id'=> 2}
+      ]
+    }.to_json
+  }
+
+  describe '#find_app_id' do
+    it 'exits system if apps_json is empty' do
+      subject = subject_class.new(mock_response.new(''))
+
+      expect(subject).to receive(:say_error).with(
+        "App not found. " \
+        "Please verify that your credentials, subdomain, and app name are correct."
+      )
+      expect { subject.find_app_id }.to raise_error(SystemExit)
+    end
+
+    it 'returns app id if is in response_with_apps' do
+      subject = subject_class.new(mock_response.new(response_with_apps))
+      allow(subject).to receive_message_chain(:cache, :save)
+      expect(subject.find_app_id).to eq(2)
+    end
+  end
+end

--- a/spec/lib/zendesk_apps_tools/deploy_spec.rb
+++ b/spec/lib/zendesk_apps_tools/deploy_spec.rb
@@ -61,7 +61,7 @@ describe ZendeskAppsTools::Deploy do
       expect { subject.find_app_id }.to raise_error(SystemExit)
     end
 
-    it 'returns app id if is in response_with_apps' do
+    it 'returns app id if app exist within response_with_apps' do
       subject = subject_class.new(mock_response.new(response_with_apps))
       allow(subject).to receive_message_chain(:cache, :save)
       expect(subject.find_app_id).to eq(2)

--- a/spec/lib/zendesk_apps_tools/deploy_spec.rb
+++ b/spec/lib/zendesk_apps_tools/deploy_spec.rb
@@ -3,31 +3,22 @@ require 'zendesk_apps_tools/deploy'
 require 'json'
 
 describe ZendeskAppsTools::Deploy do
-  let(:mock_response) do
-    Class.new do
-      attr_reader :body
-      def initialize(json_body)
-        @body = json_body
-      end
-
-      def get(uri)
-        self
-      end
-    end
+  let(:api_response) do
+   {
+     'apps'=> [
+        { 'name'=> 'notification_app', 'id'=> 22 },
+        { 'name'=> 'time_tracking_app', 'id' => 99 }
+      ]
+    }.to_json
   end
 
   let(:subject_class) do
     Class.new do
       include ZendeskAppsTools::Deploy
-      attr_reader :get_connection, :app_name
+      attr_reader :app_name
 
-      def initialize(get_response, app_name)
-        @get_connection = get_response
+      def initialize(app_name)
         @app_name = app_name
-      end
-
-      def connection(multipart = nil)
-        get_connection
       end
 
       def get_value_from_stdin(text)
@@ -38,23 +29,11 @@ describe ZendeskAppsTools::Deploy do
 
   describe '#find_app_id' do
 
-    let(:api_response) do
-      mock_response.new(
-       {
-         'apps'=> [
-            { 'name'=> 'notification_app', 'id'=> 22 },
-            { 'name'=> 'time_tracking_app', 'id' => 99 }
-          ]
-        }.to_json
-      )
-    end
-
-    let(:subject) { subject_class.new(api_response) }
-
     context 'user inputs an app name that is NOT in api response' do
       it 'errors and exits system' do
-        subject = subject_class.new(api_response, 'random_app_name')
-        allow(subject).to receive_message_chain(:say_status, :command, :text)
+        subject = subject_class.new('random_app_name')
+        allow(subject).to receive(:say_status)
+        allow(subject).to receive_message_chain(:connection, :get, :body) { api_response }
 
         expect(subject).to receive(:say_error).with(
           "App not found. " \
@@ -65,18 +44,21 @@ describe ZendeskAppsTools::Deploy do
     end
 
     context 'user inputs an app name that is in api response' do
+
       it 'returns app id 22 for notification_app' do
-        subject = subject_class.new(api_response, 'notification_app')
+        subject = subject_class.new('notification_app')
         allow(subject).to receive_message_chain(:cache, :save)
-        allow(subject).to receive_message_chain(:say_status, :command, :text)
+        allow(subject).to receive(:say_status)
+        allow(subject).to receive_message_chain(:connection, :get, :body) { api_response }
 
         expect(subject.find_app_id).to eq(22)
       end
 
       it 'returns app id 99 for notification_app' do
-        subject = subject_class.new(api_response, 'time_tracking_app')
+        subject = subject_class.new('time_tracking_app')
         allow(subject).to receive_message_chain(:cache, :save)
-        allow(subject).to receive_message_chain(:say_status, :command, :text)
+        allow(subject).to receive(:say_status)
+        allow(subject).to receive_message_chain(:connection, :get, :body) { api_response }
 
         expect(subject.find_app_id).to eq(99)
       end

--- a/spec/lib/zendesk_apps_tools/deploy_spec.rb
+++ b/spec/lib/zendesk_apps_tools/deploy_spec.rb
@@ -44,22 +44,21 @@ describe ZendeskAppsTools::Deploy do
     end
 
     context 'user inputs an app name that is in api response' do
-
-      it 'returns app id 22 for notification_app' do
-        subject = subject_class.new('notification_app')
+      define_method(:mock_methods_and_api) do |subject|
         allow(subject).to receive_message_chain(:cache, :save)
         allow(subject).to receive(:say_status)
         allow(subject).to receive_message_chain(:connection, :get, :body) { api_response }
+      end
 
+      it 'returns app id 22 for notification_app' do
+        subject = subject_class.new('notification_app')
+        mock_methods_and_api(subject)
         expect(subject.find_app_id).to eq(22)
       end
 
       it 'returns app id 99 for notification_app' do
         subject = subject_class.new('time_tracking_app')
-        allow(subject).to receive_message_chain(:cache, :save)
-        allow(subject).to receive(:say_status)
-        allow(subject).to receive_message_chain(:connection, :get, :body) { api_response }
-
+        mock_methods_and_api(subject)
         expect(subject.find_app_id).to eq(99)
       end
     end


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
While working on a sprint task, I came across some ruby code that doesn't look great. Thought I'd clean it up abit before working on that sprint task. This change follows the [Ruby Style Guide](https://github.com/rubocop-hq/ruby-style-guide).

Prior to the refactoring, I created a test for the code that is to be refactored. Then made sure that the test passes after refactoring

### Tasks
1. Write Test for method
2. Refactor method
3. Run test for new method

4. Explicitly declare external dependencies (modules)

### Implementation Notes
1. Better way to write `.empty?` condition
  ```
    response_json = ""

    app_json =  response_json.empty? ? nil : 'method_name' <--(!!!)

    app_json = 'method_name' unless response_json.empty? <---(Better way)

    (because app_json will be nil otherwise anyway)
  ```

2. get_connection was extracted into a private method, and then converted into alias_method

### References
* [StackExchange: Why write tests for code that I will refactor?](https://softwareengineering.stackexchange.com/questions/233222/why-write-tests-for-code-that-i-will-refactor)
* [Alias Method](https://blog.bigbinary.com/2012/01/08/alias-vs-alias-method.html) 
* [Original PR](https://github.com/zendesk/zendesk_apps_tools/pull/263)
* [ Ruby Style Guide](https://github.com/rubocop-hq/ruby-style-guide)

### Risks
* [low] Refactored method by first creating the test, then refactor code to pass test.
