### PR TITLE
Keith/optimize_network_client_creation

### DIFF
--- a/lib/zendesk_apps_tools/api_connection.rb
+++ b/lib/zendesk_apps_tools/api_connection.rb
@@ -29,7 +29,8 @@ module ZendeskAppsTools
     def get_connection(encoding = :url_encoded)
       require 'net/http'
       require 'faraday'
-      prepare_api_auth
+      prepare_api_auth unless @subdomain && @username && @password
+
       Faraday.new full_url do |f|
         f.request encoding if encoding
         f.adapter :net_http


### PR DESCRIPTION
/cc @zendesk/vegemite :v:

### Description
Found something to optimize in ZAT. We use Faraday Gem for our HTTP network client.

This is set up by the `APIConnection` module, specifically in the `get_connection` method. `get_connection` relies on another method called `prepare_api_auth` within the same module. 

`prepare_api_auth` prompts user for subdomain, username and password if none of these information are available in zat cache. `get_connection`, on the other hand, uses these credentials to build the network client.

## Implementation Notes
`get_connection` is called many times in `deploy.rb`. Every single `get_connection` **in a single run time** creates a new network client (faraday object) and reiterates through `prepare_api_auth` to reassign subdomain, username, password to themselves. Let's dive deeper into code!
<details>
<summary>The Problem?</summary>
<br/>
<em>we puts as indicators to understand the flow of execution</em>
<img width="802" alt="screen shot 2018-12-12 at 9 44 14 am" src="https://user-images.githubusercontent.com/17760485/49845299-31a06480-fe1a-11e8-9e35-66ac02ad92c0.png">

<br/><em>upon running zat create with input credentials, we see 4 get_connections and 4 prepare auths.</em>
<img width="810" alt="screen shot 2018-12-12 at 9 42 10 am" src="https://user-images.githubusercontent.com/17760485/49845376-93f96500-fe1a-11e8-9118-0371a2618098.png">

<br/><em>every time we go through the Faraday.new block, I had a sneaky suspicion that we were creating new Faraday Objects for deploy.md to make http request. Hence more indicators</em>
<img width="382" alt="screen shot 2018-12-12 at 9 56 40 am" src="https://user-images.githubusercontent.com/17760485/49845568-53e6b200-fe1b-11e8-9c8b-ad46b90d26d2.png">

<br/><em>Network Clients Clones</em>
<img width="811" alt="screen shot 2018-12-12 at 9 55 53 am" src="https://user-images.githubusercontent.com/17760485/49848768-d165ee80-fe2a-11e8-8e17-cc7722a2d25e.png">

<em>Out of the four objects that were created, I have identifed that 2 were necessary. The first is for our regular network connection, the second - for multipart url encoded. Three and four are just clones of the first. </em>
</details>

#### The solution

1) Inside `get_connection`, prevent `prepare_api_auth` if you already have the subdomain, username and password. In other words, execute `prepare_api_auth` unless we have @subdomain or @username or @password

    ```
    (api_connection.rb)

    def get_connection
      ...
      prepare_api_auth unless @subdomain && @username && @password
      ...(go faraday)..
    end
    ```

2) In `deploy.rb`, whenever we call `connection.send(url)`, `connection.get(url)`, or `connection.post(url)`, use the same connection. The method below caches connection in a local variable, after calling it once, which is accessible throughout `deploy.rb` in a single run time.

    ```
    (deploy.rb)

    def connection
      @connection ||= get_connection
    end
    ```
`get_connection(:multipart)` is only called once, so let's call get_connection directly on that one.

<details>
<summary>The Result?</summary>
<em>running zat create once again, we can see that there's much of an improvement.</em>
<img width="810" alt="screen shot 2018-12-12 at 10 52 39 am" src="https://user-images.githubusercontent.com/17760485/49850267-f2c9d900-fe30-11e8-8974-e9bac2cb192f.png">
Our first `get_connection` produced a faraday object with multipart url encoding. The second would be our regular one that is being recycled throughout `deploy.rb`. `prepare_api_auth` occurred just once.
</details> 


### Tasks
- [x] prevent iterating through `prepare_api_auth ` if we already have subdomain, username, and password.
- [x] write test for `get_connection` to identify how many times `prepare_api_auth` is called.
- [x] prevent creating multiple/new network client in every `deploy.md` methods, unless necessary (multipart url encoding)

### References
* no references

### Risks
* [low] - Optimize network client by reusing credentials and client that has already been defined. 