### PR TITLE
Fix email validation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (2.12.0)
+    zendesk_apps_tools (2.12.1)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)
@@ -33,7 +33,7 @@ GEM
       timers (~> 4.0.0)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.3)
     contracts (0.15.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -49,7 +49,7 @@ GEM
     cucumber-core (1.5.0)
       gherkin (~> 4.0)
     cucumber-wire (0.0.1)
-    daemons (1.2.6)
+    daemons (1.3.0)
     diff-lcs (1.3)
     erubis (2.7.0)
     eventmachine (1.2.7)
@@ -63,7 +63,7 @@ GEM
     gherkin (4.1.1)
     hashdiff (0.3.2)
     hitimes (1.3.0)
-    i18n (1.1.1)
+    i18n (1.2.0)
       concurrent-ruby (~> 1.0)
     image_size (2.0.0)
     jshintrb (0.3.0)
@@ -85,12 +85,12 @@ GEM
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     public_suffix (2.0.5)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-livereload (0.3.17)
       rack
     rack-protection (1.5.5)
       rack
-    rake (12.3.1)
+    rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -109,7 +109,7 @@ GEM
     rspec-support (3.5.0)
     rubyzip (1.2.2)
     safe_yaml (1.0.4)
-    sass (3.6.0)
+    sass (3.7.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -128,7 +128,7 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     thor (0.19.4)
-    tilt (2.0.8)
+    tilt (2.0.9)
     timers (4.0.4)
       hitimes
     webmock (2.3.2)
@@ -162,4 +162,4 @@ DEPENDENCIES
   zendesk_apps_tools!
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/lib/zendesk_apps_tools/api_connection.rb
+++ b/lib/zendesk_apps_tools/api_connection.rb
@@ -4,7 +4,7 @@ module ZendeskAppsTools
     # taken from zendesk/lib/vars.rb
     SUBDOMAIN_VALIDATION_PATTERN = /^[a-z0-9][a-z0-9\-]{1,}[a-z0-9]$/i
     ZENDESK_URL_VALIDATION_PATTERN = /^(https?):\/\/[a-z0-9]+(([\.]|[\-]{1,2})[a-z0-9]+)*\.([a-z]{2,16}|[0-9]{1,3})((:[0-9]{1,5})?(\/?|\/.*))?$/ix
-    EMAIL_REGEX  = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})(\/token:\S+)?$/i
+    EMAIL_REGEX  = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})(\/token)?$/i
 
     EMAIL_ERROR_MSG = 'Please enter a valid email address.'
     PROMPT_FOR_URL  = 'Enter your Zendesk subdomain or full URL (including protocol):'

--- a/lib/zendesk_apps_tools/api_connection.rb
+++ b/lib/zendesk_apps_tools/api_connection.rb
@@ -4,7 +4,7 @@ module ZendeskAppsTools
     # taken from zendesk/lib/vars.rb
     SUBDOMAIN_VALIDATION_PATTERN = /^[a-z0-9][a-z0-9\-]{1,}[a-z0-9]$/i
     ZENDESK_URL_VALIDATION_PATTERN = /^(https?):\/\/[a-z0-9]+(([\.]|[\-]{1,2})[a-z0-9]+)*\.([a-z]{2,16}|[0-9]{1,3})((:[0-9]{1,5})?(\/?|\/.*))?$/ix
-    EMAIL_REGEX  = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i
+    EMAIL_REGEX  = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})(\/token:\S+)?$/i
 
     EMAIL_ERROR_MSG = 'Please enter a valid email address.'
     PROMPT_FOR_URL  = 'Enter your Zendesk subdomain or full URL (including protocol):'

--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '2.12.0'
+  VERSION = '2.12.1'
 end

--- a/spec/lib/zendesk_apps_tools/api_connection_spec.rb
+++ b/spec/lib/zendesk_apps_tools/api_connection_spec.rb
@@ -2,11 +2,32 @@ require 'spec_helper'
 require 'api_connection'
 
 describe ZendeskAppsTools::APIConnection do
-  let(:subdomain_validation_pattern) { ZendeskAppsTools::APIConnection::SUBDOMAIN_VALIDATION_PATTERN }
-  let(:url_validation_pattern)       { ZendeskAppsTools::APIConnection::ZENDESK_URL_VALIDATION_PATTERN }
-  let(:default_url_template)         { ZendeskAppsTools::APIConnection::DEFAULT_URL_TEMPLATE }
+  describe 'EMAIL_REGEX' do
+    let(:email_regex) { ZendeskAppsTools::APIConnection::EMAIL_REGEX }
+    define_method(:matches_email?) { |email| !!email_regex.match(email) }
+
+    it 'does not match invalid email addresses' do
+      expect(matches_email?('username')).to eq(false)
+      expect(matches_email?('username.com')).to eq(false)
+      expect(matches_email?('u!sername@email.com')).to eq(false)
+    end
+
+    it 'will match valid email addresses' do
+      expect(matches_email?('username@email.com')).to eq(true)
+      expect(matches_email?('username123@e-mail.com')).to eq(true)
+    end
+
+    it 'will match valid email addresses with api_token' do
+      expect(matches_email?('username@email.com/token:p0K3Mon')).to eq(true)
+      expect(matches_email?('username123@e-mail.com/token:@#$123QWERasd|?:"{>')).to eq(true)
+    end
+  end
 
   describe 'CONSTANTS' do
+    let(:subdomain_validation_pattern) { ZendeskAppsTools::APIConnection::SUBDOMAIN_VALIDATION_PATTERN }
+    let(:url_validation_pattern)       { ZendeskAppsTools::APIConnection::ZENDESK_URL_VALIDATION_PATTERN }
+    let(:default_url_template)         { ZendeskAppsTools::APIConnection::DEFAULT_URL_TEMPLATE }
+
     describe 'DEFAULT_URL_TEMPLATE' do
       context '% subdomain (used in private method full_url)' do
         it 'replaces %s with subdomain in template' do
@@ -65,7 +86,7 @@ describe ZendeskAppsTools::APIConnection do
   end
 
   describe '#prepare_api_auth' do
-    let(:url_error_message) { ZendeskAppsTools::APIConnection::URL_ERROR_MSG }
+    let(:url_error_message)   { ZendeskAppsTools::APIConnection::URL_ERROR_MSG }
     let(:email_error_message) { ZendeskAppsTools::APIConnection::EMAIL_ERROR_MSG }
     let(:subject_class) do
       Class.new do

--- a/spec/lib/zendesk_apps_tools/api_connection_spec.rb
+++ b/spec/lib/zendesk_apps_tools/api_connection_spec.rb
@@ -10,6 +10,8 @@ describe ZendeskAppsTools::APIConnection do
       expect(matches_email?('username')).to eq(false)
       expect(matches_email?('username.com')).to eq(false)
       expect(matches_email?('u!sername@email.com')).to eq(false)
+      expect(matches_email?('username@email.com/token:password')).to eq(false)
+      expect(matches_email?('username@email.com/')).to eq(false)
     end
 
     it 'will match valid email addresses' do
@@ -18,8 +20,7 @@ describe ZendeskAppsTools::APIConnection do
     end
 
     it 'will match valid email addresses with api_token' do
-      expect(matches_email?('username@email.com/token:p0K3Mon')).to eq(true)
-      expect(matches_email?('username123@e-mail.com/token:@#$123QWERasd|?:"{>')).to eq(true)
+      expect(matches_email?('username@email.com/token')).to eq(true)
     end
   end
 


### PR DESCRIPTION
/cc @zendesk/vegemite :v:

### Description
After adding validation for username which is end user's email. I have not considered for users who uses API token. 

### Implementation Notes
The previous regular expression for email was
```
EMAIL_REGEX  = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i
```

This is now changed to 
```
EMAIL_REGEX  = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})(\/token:\S+)?$/i
```

<img width="970" alt="screen shot 2018-12-13 at 3 01 26 pm" src="https://user-images.githubusercontent.com/17760485/49915095-084e0a00-fee8-11e8-9fe8-743ef2e75da7.png">


### Tasks
- [x] Test email with `email@email.email/token:{api_token}`

### References
* https://zendesk.slack.com/archives/C1230V1CG/p1544631643154400

### Risks
* [low] Attempt to fix ZAT login with email that requires api_token

