### PR TITLE
Relocate cache.save zat_details

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (2.12.1)
+    zendesk_apps_tools (2.12.2)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)

--- a/lib/zendesk_apps_tools/api_connection.rb
+++ b/lib/zendesk_apps_tools/api_connection.rb
@@ -22,8 +22,6 @@ module ZendeskAppsTools
       say_error_and_exit EMAIL_ERROR_MSG unless valid_email?
 
       @password  ||= cache.fetch('password', @subdomain) || get_password_from_stdin('Enter your password:')
-
-      cache.save 'subdomain' => @subdomain, 'username' => @username
     end
 
     def get_connection(encoding = :url_encoded)

--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -129,13 +129,12 @@ module ZendeskAppsTools
     private
 
     def zat_details(response)
-      zat_details = {}
+      zat_details = {
+        'subdomain' => @subdomain,
+        'username' => @username
+      }
 
-      zat_details['app_id']    = response['app_id'] if response['app_id']
-      zat_details['subdomain'] = @subdomain
-      zat_details['username']  = @username
-
-      zat_details
+      zat_details.merge('app_id' => response['app_id']) if response['app_id']
     end
   end
 end

--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -110,7 +110,7 @@ module ZendeskAppsTools
         if %w(completed failed).include? status
           case status
           when 'completed'
-            cache.save zat_details(response)
+            cache.save zat_contents(response)
             say_status @command, 'OK'
           when 'failed'
             say_status @command, response['message'], :red
@@ -128,13 +128,13 @@ module ZendeskAppsTools
 
     private
 
-    def zat_details(response)
-      zat_details = {
-        'subdomain' => @subdomain,
-        'username' => @username
-      }
+    def zat_contents(response)
+      zat = {}
+      zat['subdomain'] = @subdomain
+      zat['username'] = @username
+      zat['app_id'] = response['app_id'] if response['app_id']
 
-      zat_details.merge('app_id' => response['app_id']) if response['app_id']
+      zat
     end
   end
 end

--- a/spec/lib/zendesk_apps_tools/deploy_spec.rb
+++ b/spec/lib/zendesk_apps_tools/deploy_spec.rb
@@ -75,7 +75,7 @@ describe ZendeskAppsTools::Deploy do
         subject = subject_class.new
         allow(subject).to receive_message_chain(:connection, :get, :body) { completed_api_response_body }
         allow(subject).to receive_message_chain(:cache, :save)
-        allow(subject).to receive(:say_status).with(nil, "OK")
+        allow(subject).to receive(:say_status).with(@command, "OK")
 
         subject.check_job(random_job_id)
       end

--- a/spec/lib/zendesk_apps_tools/deploy_spec.rb
+++ b/spec/lib/zendesk_apps_tools/deploy_spec.rb
@@ -52,4 +52,33 @@ describe ZendeskAppsTools::Deploy do
       end
     end
   end
+
+  describe '#check_job' do
+    let(:failed_api_response_body) { { 'status' => 'failed', 'message' => 'You failed!' }.to_json }
+    let(:completed_api_response_body){ { 'status' => 'completed', 'app_id' => 2}.to_json }
+    let(:random_job_id) { 9999 }
+
+    let(:subject_class) { Class.new { include ZendeskAppsTools::Deploy } }
+    let(:subject) { subject_class.new }
+
+    context 'response status is failed' do
+      it 'errors and exit' do
+        allow(subject).to receive_message_chain(:connection, :get, :body) { failed_api_response_body }
+        allow(subject).to receive(:say_status).with(@command, 'You failed!', :red) { exit }
+
+        expect { subject.check_job(random_job_id)}.to raise_error(SystemExit)
+      end
+    end
+
+    context 'response status is completed' do
+      it 'caches subdomain, username and app_id' do
+        subject = subject_class.new
+        allow(subject).to receive_message_chain(:connection, :get, :body) { completed_api_response_body }
+        allow(subject).to receive_message_chain(:cache, :save)
+        allow(subject).to receive(:say_status).with(nil, "OK")
+
+        subject.check_job(random_job_id)
+      end
+    end
+  end
 end

--- a/spec/lib/zendesk_apps_tools/deploy_spec.rb
+++ b/spec/lib/zendesk_apps_tools/deploy_spec.rb
@@ -3,37 +3,30 @@ require 'zendesk_apps_tools/deploy'
 require 'json'
 
 describe ZendeskAppsTools::Deploy do
-  let(:api_response) do
-   {
-     'apps'=> [
-        { 'name'=> 'notification_app', 'id'=> 22 },
-        { 'name'=> 'time_tracking_app', 'id' => 99 }
-      ]
-    }.to_json
-  end
-
-  let(:subject_class) do
-    Class.new do
-      include ZendeskAppsTools::Deploy
-      attr_reader :app_name
-
-      def initialize(app_name)
-        @app_name = app_name
-      end
-
-      def get_value_from_stdin(text)
-        app_name
-      end
-    end
-  end
-
   describe '#find_app_id' do
+    let(:api_response_with_app_ids) do
+     {
+       'apps'=> [
+          { 'name'=> 'notification_app', 'id'=> 22 },
+          { 'name'=> 'time_tracking_app', 'id' => 99 }
+        ]
+      }.to_json
+    end
+
+    let(:subject_class) { Class.new { include ZendeskAppsTools::Deploy } }
+
+    define_method(:mocked_instance_methods_and_api) do |app_name|
+      subject = subject_class.new
+      allow(subject).to receive(:say_status)
+      allow(subject).to receive(:get_value_from_stdin) { app_name }
+      allow(subject).to receive_message_chain(:connection, :get, :body) { api_response_with_app_ids }
+
+      subject
+    end
 
     context 'user inputs an app name that is NOT in api response' do
       it 'errors and exits system' do
-        subject = subject_class.new('random_app_name')
-        allow(subject).to receive(:say_status)
-        allow(subject).to receive_message_chain(:connection, :get, :body) { api_response }
+        subject = mocked_instance_methods_and_api('random_app_name')
 
         expect(subject).to receive(:say_error).with(
           "App not found. " \
@@ -44,21 +37,17 @@ describe ZendeskAppsTools::Deploy do
     end
 
     context 'user inputs an app name that is in api response' do
-      define_method(:mock_methods_and_api) do |subject|
-        allow(subject).to receive_message_chain(:cache, :save)
-        allow(subject).to receive(:say_status)
-        allow(subject).to receive_message_chain(:connection, :get, :body) { api_response }
-      end
-
       it 'returns app id 22 for notification_app' do
-        subject = subject_class.new('notification_app')
-        mock_methods_and_api(subject)
+        subject = mocked_instance_methods_and_api('notification_app')
+        allow(subject).to receive_message_chain(:cache, :save)
+
         expect(subject.find_app_id).to eq(22)
       end
 
       it 'returns app id 99 for notification_app' do
-        subject = subject_class.new('time_tracking_app')
-        mock_methods_and_api(subject)
+        subject = mocked_instance_methods_and_api('time_tracking_app')
+        allow(subject).to receive_message_chain(:cache, :save)
+
         expect(subject.find_app_id).to eq(99)
       end
     end

--- a/spec/lib/zendesk_apps_tools/deploy_spec.rb
+++ b/spec/lib/zendesk_apps_tools/deploy_spec.rb
@@ -54,17 +54,17 @@ describe ZendeskAppsTools::Deploy do
   end
 
   describe '#check_job' do
-    let(:failed_api_response_body) { { 'status' => 'failed', 'message' => 'You failed!' }.to_json }
-    let(:completed_api_response_body){ { 'status' => 'completed', 'app_id' => 2}.to_json }
     let(:random_job_id) { 9999 }
+    let(:completed_api_response_body) { {'status' => 'completed'} }
+    let(:failed_api_response_body)    { {'status' => 'failed', 'message' => 'You failed!'} }
 
     let(:subject_class) { Class.new { include ZendeskAppsTools::Deploy } }
     let(:subject) { subject_class.new }
 
     context 'response status is failed' do
       it 'errors and exit' do
-        allow(subject).to receive_message_chain(:connection, :get, :body) { failed_api_response_body }
-        allow(subject).to receive(:say_status).with(@command, 'You failed!', :red) { exit }
+        allow(subject).to receive_message_chain(:connection, :get, :body) { failed_api_response_body.to_json  }
+        allow(subject).to receive(:say_status).with(@command, failed_api_response_body['message'], :red) { exit }
 
         expect { subject.check_job(random_job_id)}.to raise_error(SystemExit)
       end
@@ -73,7 +73,7 @@ describe ZendeskAppsTools::Deploy do
     context 'response status is completed' do
       it 'caches subdomain, username and app_id' do
         subject = subject_class.new
-        allow(subject).to receive_message_chain(:connection, :get, :body) { completed_api_response_body }
+        allow(subject).to receive_message_chain(:connection, :get, :body) { completed_api_response_body.to_json  }
         allow(subject).to receive_message_chain(:cache, :save)
         allow(subject).to receive(:say_status).with(@command, "OK")
 


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
In the past, when a wrong `subdomain` or `username` is entered during a `zat_update` or `zat_create`, the connection fails and these details are stored in a cache file locally. In subsequent attempts, zat will look into the local cache file to reconnect using the wrong `subdomain` or `username`. 

This is because `subdomain` and `username` are stored directly after user prompts. Instead, they should be stored after a successful connection. This successful connection occurs and is defined when API `response.body['status']` is [**completed**](https://github.com/zendesk/zendesk_apps_tools/blob/master/lib/zendesk_apps_tools/deploy.rb#L112).

### Implementation Notes

#### 1) Decision to piggyback off [cache.save 'app_id'](https://github.com/zendesk/zendesk_apps_tools/blob/master/lib/zendesk_apps_tools/deploy.rb#L114)
Felt that this is a good place to cache [instance variables `subdomain` and `username`](https://github.com/zendesk/zendesk_apps_tools/blob/master/lib/zendesk_apps_tools/api_connection.rb#L26). Reasons: 
- Instance Variables meant that they are accessible across modules.
- These Variables are set - after `ZendeskAppsTools::APIConnection#get_connection` has already been called ([and potentially cached](https://github.com/zendesk/zendesk_apps_tools/pull/267)) earlier on.
- This occurs within the `case when` the `request.body['status']` is [completed](https://github.com/zendesk/zendesk_apps_tools/blob/master/lib/zendesk_apps_tools/deploy.rb#L112) block. Meaning the connection has already been established, and `username`/`subdomain` are valid.
- ALL methods in Deploy EVENTUALLY ends up in this block anyway. INCLUDING `app_exists?`, `upload` and `find_app_id`. ~Just like the river and the ocean~

#### 2) Decision to rename [info](https://github.com/zendesk/zendesk_apps_tools/blob/master/lib/zendesk_apps_tools/deploy.rb#L107) to zat_details

<details>
<summary>Info seems to be a reserved ruby/system keyword</summary>
<em>When hash is info</em>
<img width="689" alt="hash before renamed" src="https://user-images.githubusercontent.com/17760485/50131038-76be0e00-02d4-11e9-8dc7-423bbbe093c1.png">
<em>When hash is renamed to response</em>
<img width="697" alt="hash after renamed" src="https://user-images.githubusercontent.com/17760485/50133669-a07d3200-02e0-11e9-8b21-167518d5717d.png">

</details>

#### 3) Decision to pass the ENTIRE RESPONSE into private method zat_details as param

Essentially, private method zat_details becomes a wrapper method that returns a hash object, as such

```
cache.save sexy_hash

private

def sexy_hash
  {
    key_1: 'value_1',
    key_2: 'value_2',
    key_3: 'value_3'
  }
end
```
which is equivalent to `cache.save 'key_1' => 'value_1', 'key_2' => 'value_2', 'key_3' => 'value_3'`. Smaller blocks and methods reads a whole lot easier. Along with this approach, I have also identified a few areas in the current script to improve in the **next PR**.

**4) Optional reading: Storing App Id or App Name to [response](https://github.com/zendesk/zendesk_apps_tools/blob/master/lib/zendesk_apps_tools/deploy.rb#L66)**
Response return a bunch of powerful information. <details> <summary>What powerful information you ask?
</summary>
<img width="699" alt="reasons for passing response" src="https://user-images.githubusercontent.com/17760485/50132187-ea164e80-02d9-11e9-9e20-8d6d187fec08.png">
</details>

With app_name, app_id and app_url, we can avoid prompting users for app_name, or even executing `find_app_id` from `/api/apps.json`  😱 ~wait till you see the response data~ We can potentially store more things in zat cache. This is implementation work for another day. 

### Screenshot
Result
<img width="722" alt="screen shot 2018-12-18 at 4 09 00 pm" src="https://user-images.githubusercontent.com/17760485/50133434-a888a200-02df-11e9-9773-0d04b6de33ff.png">

### Tasks
- [x] Document approach and decision.
- [x] Write Test for ~cache?~ check_job method

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-1433

### Risks
* [low] Relocate cache.save `subdomain` and `username`. Cached details are only complementary. 
