### PR TITLE
Update apps.json url to v2 endpoint

### DIFF
--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -64,7 +64,6 @@ module ZendeskAppsTools
 
     def find_app_id
       say_status 'Update', 'app ID is missing, searching...'
-
       app_name = cache.fetch('app_name') || get_value_from_stdin('Enter the name of the app:')
 
       all_apps_json = cached_connection.get('/api/v2/apps.json').body

--- a/lib/zendesk_apps_tools/deploy.rb
+++ b/lib/zendesk_apps_tools/deploy.rb
@@ -64,9 +64,10 @@ module ZendeskAppsTools
 
     def find_app_id
       say_status 'Update', 'app ID is missing, searching...'
-      app_name = get_value_from_stdin('Enter the name of the app:')
 
-      all_apps_json = cached_connection.get('/api/apps.json').body
+      app_name = cache.fetch('app_name') || get_value_from_stdin('Enter the name of the app:')
+
+      all_apps_json = cached_connection.get('/api/v2/apps.json').body
 
       app =
         unless all_apps_json.empty?
@@ -80,7 +81,7 @@ module ZendeskAppsTools
         )
       end
 
-      cache.save 'app_id' => app['id']
+      cache.save 'app_id' => app['id'], 'app_name' => app['name']
       app['id']
 
     rescue Faraday::Error::ClientError => e
@@ -130,6 +131,7 @@ module ZendeskAppsTools
       zat['subdomain'] = @subdomain
       zat['username'] = @username
       zat['app_id'] = response['app_id'] if response['app_id']
+      zat['app_id'] = response['app_name'] if response['app_name']
 
       zat
     end

--- a/spec/lib/zendesk_apps_tools/command_spec.rb
+++ b/spec/lib/zendesk_apps_tools/command_spec.rb
@@ -150,9 +150,10 @@ describe ZendeskAppsTools::Command do
       end
 
       it 'cannot find the app id' do
-        stub_request(:get, PREFIX + '/api/apps.json')
+        stub_request(:get, PREFIX + '/api/v2/apps.json')
           .with(headers: AUTHORIZATION_HEADER)
           .to_return(body: '')
+
         expect(@command).to receive(:say_error).with(
           "App not found. " \
           "Please verify that your credentials, subdomain, and app name are correct."
@@ -161,7 +162,7 @@ describe ZendeskAppsTools::Command do
       end
 
       it 'finds the app id' do
-        stub_request(:get, PREFIX + '/api/apps.json')
+        stub_request(:get, PREFIX + '/api/v2/apps.json')
           .with(headers: AUTHORIZATION_HEADER)
           .to_return(body: JSON.generate(apps))
         stub_request(:get, PREFIX + '/api/v2/apps/125.json')

--- a/spec/lib/zendesk_apps_tools/deploy_spec.rb
+++ b/spec/lib/zendesk_apps_tools/deploy_spec.rb
@@ -18,6 +18,7 @@ describe ZendeskAppsTools::Deploy do
     define_method(:mocked_instance_methods_and_api) do |app_name|
       subject = subject_class.new
       allow(subject).to receive(:say_status)
+      allow(subject).to receive_message_chain(:cache, :fetch)
       allow(subject).to receive(:get_value_from_stdin) { app_name }
       allow(subject).to receive_message_chain(:cached_connection, :get, :body) { api_response_with_app_ids }
 


### PR DESCRIPTION
/cc @zendesk/vegemite :v:

### Description
When we do `zat update`, ZAT does the following:

1) Finds out what is the [**app_name** from user input](https://github.com/zendesk/zendesk_apps_tools/blob/master/lib/zendesk_apps_tools/deploy.rb#L67)
2) Finds out the [**app_id** via the app name by making an api call to ~cough~ _/api/apps.json_](https://github.com/zendesk/zendesk_apps_tools/blob/master/lib/zendesk_apps_tools/deploy.rb#L69)
3) Insert the [app_id into `/api/v2/apps/#{app_id}.json`](https://github.com/zendesk/zendesk_apps_tools/blob/master/lib/zendesk_apps_tools/deploy.rb#L71)
4) Update the app in zendesk instance through another api request.

This doesn't work because the api end point should be '/api/v2/apps.json' instead of '/api/apps.json'

### Tasks
- [ ] Checkin with someone that this was not intentional (@zendesk/wombat endpoint)
- [x] Update existing tests

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-1466

### Risks
* [low] Bug fix - Update url for API endpoint to fetch all apps.json for zat update