### PR TITLE
[AF-1509] Bump zendesk_apps_support to 4.12.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     ffi (1.9.25)
     gherkin (4.1.3)
     hashdiff (0.3.8)
-    hitimes (1.3.1)
+    hitimes (1.3.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     image_size (2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,8 +98,8 @@ GEM
       rack
     rake (12.3.2)
     rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     gherkin (4.1.3)
     hashdiff (0.3.8)
     hitimes (1.3.0)
-    i18n (1.6.0)
+    i18n (1.5.1)
       concurrent-ruby (~> 1.0)
     image_size (2.0.0)
     jshintrb (0.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.7.2)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.10.0)
+      zendesk_apps_support (~> 4.12.4)
 
 GEM
   remote: https://rubygems.org/
@@ -34,7 +34,7 @@ GEM
       timers (~> 4.0.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.5)
     contracts (0.16.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -68,15 +68,15 @@ GEM
     ffi (1.9.25)
     gherkin (4.1.3)
     hashdiff (0.3.8)
-    hitimes (1.3.0)
-    i18n (1.5.1)
+    hitimes (1.3.1)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     image_size (2.0.0)
     jshintrb (0.3.0)
       execjs
       multi_json (>= 1.3)
       rake
-    json (2.1.0)
+    json (2.2.0)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
@@ -84,12 +84,12 @@ GEM
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     multi_json (1.13.1)
     multi_test (0.1.2)
     multipart-post (2.0.0)
-    nokogiri (1.6.8.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
     public_suffix (3.0.3)
     rack (1.6.11)
     rack-livereload (0.3.17)
@@ -98,8 +98,8 @@ GEM
       rack
     rake (12.3.2)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -144,14 +144,14 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    zendesk_apps_support (4.10.0)
+    zendesk_apps_support (4.12.4)
       erubis
       i18n
       image_size
       jshintrb (~> 0.3.0)
       json
-      loofah
-      nokogiri (~> 1.6.8)
+      loofah (~> 2.2.3)
+      nokogiri (~> 1.8.5)
       sass
       sassc (~> 1.11.2)
 

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.10.0'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.12.4'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'
   s.add_runtime_dependency 'rack-livereload'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Peremptory cautionary imperative and cursory preamble

⚠️ *** DO NOT MERGE EVEN WITH 2 +1s *** ⚠️ 

This change requires devqa first.

### Description
There was a need to bump a dependency in zendesk_apps_support to address a security alert.  This change is to bump zendesk_apps_support in zendesk_apps_tools to make sure that the patched version of zas is being used in zat.

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-1509
* https://github.com/zendesk/zendesk_apps_support/pull/220
* https://github.com/zendesk/zendesk_apps_support/compare/f5166cf783b726f0f96a3e6c9972def99312182c...90dbafcf1b8cb9b6fc5f4e14c1143c9b9021e2a8

### Risks
* Medium: Significant bump of zas in zat.  zas has not been bumped in about a year.  Could cause zat to break in unknown ways due to accumulated changes over said period.
