### PR TITLE
Expose plan information to app developers - allow `--plan=gold` and plan in .zat file - take 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.7.2)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.15.0)
+      zendesk_apps_support (~> 4.15.1)
 
 GEM
   remote: https://rubygems.org/
@@ -115,7 +115,7 @@ GEM
     rspec-support (3.8.0)
     rubyzip (1.2.2)
     safe_yaml (1.0.4)
-    sass (3.7.3)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -144,7 +144,7 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    zendesk_apps_support (4.15.0)
+    zendesk_apps_support (4.15.1)
       erubis
       i18n
       image_size
@@ -152,6 +152,7 @@ GEM
       json
       loofah (~> 2.2.3)
       nokogiri (~> 1.8.5)
+      rb-inotify (= 0.9.10)
       sass
       sassc (~> 1.11.2)
 

--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -158,6 +158,7 @@ module ZendeskAppsTools
     method_option :port, default: DEFAULT_SERVER_PORT, required: false, desc: 'Port for the http server to use.'
     method_option :app_id, default: DEFAULT_APP_ID, required: false, type: :numeric
     method_option :bind, required: false
+    method_option :plan, required: false
     def server
       setup_path(options[:path])
       if app_package.has_file?('assets/app.js')
@@ -173,6 +174,7 @@ module ZendeskAppsTools
         server.set :public_folder, File.join(options[:path], 'assets')
         server.set :parameters, settings
         server.set :app_id, options[:app_id]
+        server.set :plan, [options[:plan], cache.fetch('plan')].reject(&:nil?).first
         server.run!
       end
     end

--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -34,7 +34,8 @@ module ZendeskAppsTools
         collapsible: true,
         settings: settings.parameters.merge(title: app_name),
         updated_at: Time.now.iso8601,
-        created_at: Time.now.iso8601
+        created_at: Time.now.iso8601,
+        plan: { name: settings.plan }
       )
 
       app_js = package.compile(

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.15.0'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.15.1'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'
   s.add_runtime_dependency 'rack-livereload'


### PR DESCRIPTION
@zendesk/wombat 

/cc @zendesk/vegemite

### Description
Take 2 - fixing bad merge with master
- ZAS bump which exposes the plan information to app developers
- allow plan argument to be passed in zat server and to be put in the .zat file

### References
* JIRA: https://zendesk.atlassian.net/browse/APPS-4597

### Risks
* low - breaks `zat server`
