### PR TITLE
Ensure warnings raised from ZAS are consistent with internal warnings

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -102,14 +102,12 @@ module ZendeskAppsTools
       valid = errors.none?
 
       if valid
-        app_package.warnings.each { |w| say w.to_s, :yellow }
+        app_package.warnings.each { |w| say_status 'warning', w.to_s, :yellow }
         # clean when all apps are upgraded
         run_deprecation_checks unless options[:'unattended']
         say_status 'validate', 'OK'
       else
-        errors.each do |e|
-          say_status 'validate', e.to_s, :red
-        end
+        errors.each { |e| say_status 'validate', e.to_s, :red }
       end
 
       @destination_stack.pop if options[:path]
@@ -124,7 +122,10 @@ module ZendeskAppsTools
 
       setup_path(options[:path])
 
-      say_status 'warning', 'Please note that the name key of manifest.json is currently only used in development.', :yellow if app_package.manifest.name
+      if app_package.manifest.name
+        warning = 'Please note that the name key of manifest.json is currently only used in development.'
+        say_status 'warning', warning, :yellow
+      end
 
       archive_path = File.join(tmp_dir, "app-#{Time.now.strftime('%Y%m%d%H%M%S')}.zip")
 
@@ -162,7 +163,8 @@ module ZendeskAppsTools
     def server
       setup_path(options[:path])
       if app_package.has_file?('assets/app.js')
-        say 'Warning: creating assets/app.js causes zat server to behave badly.', :yellow
+        warning = 'Warning: creating assets/app.js causes zat server to behave badly.'
+        say_status 'warning', warning, :yellow
       end
 
       require 'zendesk_apps_tools/server'


### PR DESCRIPTION
:v:
/cc @zendesk/vegemite, @zendesk/dingo

### Description
As part of the automated security checks, we want **ZAS** validation warnings to appear in **ZAT** and **ZAM** (via `Apps Approval`)

One of the checks involve checking for secrets and api-keys that developers might have accidentally left in the code base - this is **not a blocking error**, however, **we want to warn developers about this**.

**ZAS** will pass these warnings to **ZAT** via an attribute called `warnings` in an instance of class **ZendeskAppsSupport::Package** (Checkout in ZAS)

#### Steps: 
**instance creation:**
`app_package = ZendeskAppsSupport::Package.new(app_directory.to_s)`

**instance.warnings:**
we execute `app_package.validate` somewhere resulting in `app_package.warnings` being filled if there are any warnings

**displaying warnings**
We display it like this `app_package.warnings.each { |w| say w.to_s, :yellow }`

### Approach
To standardise this, we just have to ensure that package.warnings are displayed like the other warnings as such
```
say_status 'warning', warning_message, :yellow
say_status 'warning', 'Unable to check for new versions of zendesk_apps_tools gem', :yellow
```
Easy!

#### Before screenshot
![current_warning](https://user-images.githubusercontent.com/17760485/59328550-fd0d5700-8d2f-11e9-9985-dd67e651d3c2.png)

#### After screenshot
![Screen Shot 2019-06-12 at 5 04 14 pm](https://user-images.githubusercontent.com/17760485/59330205-32b43f00-8d34-11e9-84db-0c8db9257251.png)

### References
* JIRA: https://zendesk.atlassian.net/browse/MPORT-480

### Risks
* Low - ZAT `validate`/`package` command fails silently without warnings