### PR TITLE
Allow port to be set in the asset tags for theme previews.

### DIFF
--- a/lib/zendesk_apps_tools/theme.rb
+++ b/lib/zendesk_apps_tools/theme.rb
@@ -102,17 +102,17 @@ module ZendeskAppsTools
       def inject_external_tags(head_template)
         live_reload_script_tag = <<-html
           <script type="text/javascript">
-            RACK_LIVERELOAD_PORT = 4567;
+            RACK_LIVERELOAD_PORT = #{options[:port]};
           </script>
-          <script src="http://localhost:4567/__rack/livereload.js?host=localhost"></script>
+          <script src="http://localhost:#{options[:port]}/__rack/livereload.js?host=localhost"></script>
         html
 
         js_tag = <<-html
-          <script src="http://localhost:4567/guide/script.js"></script>
+          <script src="http://localhost:#{options[:port]}/guide/script.js"></script>
         html
 
         css_tag = <<-html
-          <link rel="stylesheet" type="text/css" href="http://localhost:4567/guide/style.css">
+          <link rel="stylesheet" type="text/css" href="http://localhost:#{options[:port]}/guide/style.css">
         html
 
         template = StringIO.new


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
While setting a non standard port, scripts for the template were still getting injected with the standard port. Updated to respect the :port option when it is set using the standard options set and inject the appropriate script/style tags into the doc head.

### Tasks
- [ x] Include comments/inline docs where appropriate
- [ x] Write tests

### References

### Risks
* [medium] Does it work on windows? Unable to verify
* [low] Does it work in the different products (Support, Chat)? Only for the form preview
* [low] Are there any performance implications? Optional port change should not effect performance.
* [medium] Any security risks? Allowing script tag to follow the port set from the CLI.
* [low] What features does this touch? The template live preview server.
