### PR TITLE
[AF-1478] Bump ruby version to 2.1

### DIFF
--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Tools to help you develop Zendesk Apps.'
   s.description = s.summary
 
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.1'
   s.required_rubygems_version = '>= 1.3.6'
 
   s.add_runtime_dependency 'thor',        '~> 0.19.4'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
This PR is to bump the required Ruby version for ZAT to 2.1 or above. I do not think this PR will work on its own as ZAT has dependencies on ZAS which currently requires Ruby 2.3 for the i18n gem. Argh!

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Write tests

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-1478

### Risks
* [HIGH | medium | low] Does it work on windows?
* [HIGH | medium | low] Does it work in the different products (Support, Chat)?
* [HIGH | medium | low] Are there any performance implications?
* [HIGH | medium | low] Any security risks?
* [HIGH | medium | low] What features does this touch?
