### PR TITLE
Bump ZAT to 2.14 with new ZAS 4.18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.7.2)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.15.1)
+      zendesk_apps_support (~> 4.18.0)
 
 GEM
   remote: https://rubygems.org/
@@ -71,11 +71,8 @@ GEM
     hitimes (1.3.0)
     i18n (1.5.1)
       concurrent-ruby (~> 1.0)
-    image_size (2.0.0)
-    jshintrb (0.3.0)
-      execjs
-      multi_json (>= 1.3)
-      rake
+    image_size (2.0.1)
+    ipaddress_2 (0.13.0)
     json (2.2.0)
     listen (2.10.1)
       celluloid (~> 0.16.0)
@@ -84,6 +81,7 @@ GEM
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    mimemagic (0.3.3)
     mini_portile2 (2.3.0)
     multi_json (1.13.1)
     multi_test (0.1.2)
@@ -143,14 +141,15 @@ GEM
       hashdiff
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
-    zendesk_apps_support (4.15.1)
+    websocket-extensions (0.1.4)
+    zendesk_apps_support (4.18.0)
       erubis
       i18n
       image_size
-      jshintrb (~> 0.3.0)
+      ipaddress_2 (~> 0.13.0)
       json
       loofah (~> 2.2.3)
+      mimemagic (~> 0.3.3)
       nokogiri (~> 1.8.5)
       rb-inotify (= 0.9.10)
       sass

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (2.13.5)
+    zendesk_apps_tools (2.14.0)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)
@@ -94,7 +94,6 @@ GEM
       rack
     rack-protection (1.5.5)
       rack
-    rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)

--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '2.13.5'
+  VERSION = '2.14.0'
 end

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.15.1'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.18.0'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'
   s.add_runtime_dependency 'rack-livereload'


### PR DESCRIPTION
:v:
/cc @zendesk/vegemite, @zendesk/dingo 

### Description
New ZAS Version 4.18. This PR is to bump and release ZAT version 2.14

### References
* JIRA: https://zendesk.atlassian.net/browse/MPORT-443
* JIRA: https://zendesk.atlassian.net/browse/MPORT-498

### Risks
* [low] Command line ZAT create or upgrade prints incorrect warnings
