### PR TITLE
Bump ZAT to 3.1 with ZAS v4.18.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (3.0.0)
+    zendesk_apps_tools (3.1.0)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)
@@ -12,7 +12,7 @@ PATH
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.7.2)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.17.0)
+      zendesk_apps_support (~> 4.18.0)
 
 GEM
   remote: https://rubygems.org/
@@ -72,10 +72,7 @@ GEM
     i18n (1.5.1)
       concurrent-ruby (~> 1.0)
     image_size (2.0.0)
-    jshintrb (0.3.0)
-      execjs
-      multi_json (>= 1.3)
-      rake
+    ipaddress_2 (0.13.0)
     json (2.2.0)
     listen (2.10.1)
       celluloid (~> 0.16.0)
@@ -145,11 +142,11 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    zendesk_apps_support (4.17.0)
+    zendesk_apps_support (4.18.0)
       erubis
       i18n
       image_size
-      jshintrb (~> 0.3.0)
+      ipaddress_2 (~> 0.13.0)
       json
       loofah (~> 2.2.3)
       mimemagic (~> 0.3.3)
@@ -166,6 +163,7 @@ DEPENDENCIES
   bump
   byebug
   cucumber
+  rake
   rspec
   webmock
   zendesk_apps_tools!

--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '3.0.0'
+  VERSION = '3.1.0'
 end

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.17.0'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.18.0'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'
   s.add_runtime_dependency 'rack-livereload'
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bump'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'byebug'
+  s.add_development_dependency 'rake'
 
   s.files        = Dir.glob('{bin,lib,app_template*,templates}/**/*') + %w[README.md LICENSE]
   s.test_files   = Dir.glob('features/**/*')


### PR DESCRIPTION
:v: /cc @zendesk/vegemite, @zendesk/dingo 

### Description
Bumping ZAT to 2.14 for release. Changes should inherit ZAT v4.18 as a direct dependency
Changes would include
- [Update Source Validation and Remove jshintrb](https://github.com/zendesk/zendesk_apps_support/pull/234), and
- [Add strings for insecure and block-listed request warnings/errors](https://github.com/zendesk/zendesk_apps_support/pull/231).

### After merge TODOs
- [ ] Create a tag for 3.1.0 (bump minor)
- [ ] Push gem Ruby Gems and tag on Github

### References
* JIRA: https://zendesk.atlassian.net/browse/MPORT-443
* JIRA: https://zendesk.atlassian.net/browse/MPORT-498


### Risks
* [low] ZAT command does not print the right warnings
