### PR TITLE
Bump ZAT to v3.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (3.0.0)
+    zendesk_apps_tools (3.1.1)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)

--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '3.0.0'
+  VERSION = '3.1.1'
 end


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite @zendesk/dingo 

### Description
Bump Version to 3.1.1 which is actually secretly 3.0.0. This is because ZAT 3.1.0 is a bad version

### Risks
* [low] ZAT doesnt work. Cannot deploy apps
