### PR TITLE
[AF-1656] Articulate how to safely bump ZAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Then, comment-out the line referring to `zendesk_apps_support` in this project's
 
 The path should point to your local ZAS directory. In this way, your clone of ZAT will use a local version of ZAS, which is very helpful for development. Run a `bundle install` after changing the Gemfile.
 
+## Bumping ZAT
+
+If you want to bump ZAT, run `bump patch|minor|major --no-bundle` from the root directory.  This is in order to circumvent a bundle update command that [bump](https://github.com/gregorym/bump) runs by default.
+
 ## Testing
 This project uses rspec, which you can run with `bundle exec rake`.
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Then, comment-out the line referring to `zendesk_apps_support` in this project's
 
 The path should point to your local ZAS directory. In this way, your clone of ZAT will use a local version of ZAS, which is very helpful for development. Run a `bundle install` after changing the Gemfile.
 
-## Bumping ZAT
+## Deploy ZAT
 
-If you want to bump ZAT, run `bump patch|minor|major --no-bundle` from the root directory.  This is in order to circumvent a bundle update command that [bump](https://github.com/gregorym/bump) runs by default.
+* To bump ZAT version, run `bump patch|minor|major --no-bundle` from the root directory. **Note:** `--no-bundle` is required in order to prevent `bundle update` command from running, which is by default triggered by the [bump](https://github.com/gregorym/bump) gem and could lead to incompatible dependencies.
+* To publish ZAT to [Rubygems](https://rubygems.org/gems/zendesk_apps_tools), run `bundle exec rake release`.
 
 ## Testing
 This project uses rspec, which you can run with `bundle exec rake`.


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
`bump patch|minor|major` by default runs a bundle update on zat.  It is possible to circumvent this by appending `--no-bundle` to said command.  This change is to document this in the Readme.

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-1656

### Risk
None. Updating README.md only.