### PR TITLE
[AF-1656] Add safe bump tasks and use these tasks when publishing zat

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'bundler/gem_tasks'
+require 'rake'
 require 'rake/clean'
 require 'cucumber/rake/task'
 require 'rspec/core/rake_task'
@@ -13,3 +14,12 @@ Cucumber::Rake::Task.new do |t|
 end
 
 task default: [:spec, :cucumber]
+
+namespace :bump do
+  (Bump::Bump::BUMPS + ["current", "file", "show-next"]).each do |bump|
+    task (bump + ':safe') do |t|
+      cmd = "bundle exec rake bump:" + bump + " " + "BUNDLE=false"
+      exec(cmd)
+    end
+  end
+end


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Adds new tasks `bundle exec rake bump:patch|minor|major:safe`.

These tasks bump the version of zat, without doing a bundle update.

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Write tests

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-1656
