### PR TITLE
Bump ZAT to v3.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (3.1.2)
+    zendesk_apps_tools (3.2.0)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)
@@ -12,7 +12,7 @@ PATH
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.7.2)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.20.0)
+      zendesk_apps_support (~> 4.21.0)
 
 GEM
   remote: https://rubygems.org/
@@ -142,7 +142,7 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    zendesk_apps_support (4.20.0)
+    zendesk_apps_support (4.21.0)
       erubis
       i18n
       image_size

--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '3.1.2'
+  VERSION = '3.2.0'
 end

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.20.0'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.21.0'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'
   s.add_runtime_dependency 'rack-livereload'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Quite similar to the previous [ZAS bump](https://github.com/zendesk/zendesk_apps_support/pull/243). I am pushing this up to see if it successfully builds on travis. This is bumped manually to avoid rake bump minor which would bump the bundle with version in Gemfile. 

### QA screenshots
![Screen Shot 2019-07-29 at 2 33 24 pm](https://user-images.githubusercontent.com/17760485/62022102-f2d6e780-b20d-11e9-8c5e-41feb181dcaf.png)
![Screen Shot 2019-07-29 at 2 33 17 pm](https://user-images.githubusercontent.com/17760485/62022104-f2d6e780-b20d-11e9-9dad-c0724dca599d.png)

### Risks
* [low] All the QA test has been done and approved in previous tasks, in ZAS.