### PR TITLE
Support api version in zat theme preview

### DIFF
--- a/lib/zendesk_apps_tools/theme.rb
+++ b/lib/zendesk_apps_tools/theme.rb
@@ -96,6 +96,7 @@ module ZendeskAppsTools
         payload['templates']['js'] = ''
         payload['templates']['assets'] = assets
         payload['templates']['variables'] = settings_hash
+        payload['templates']['metadata'] = metadata_hash
         payload
       end
 

--- a/lib/zendesk_apps_tools/theming/common.rb
+++ b/lib/zendesk_apps_tools/theming/common.rb
@@ -45,6 +45,10 @@ module ZendeskAppsTools
         end
       end
 
+      def metadata_hash
+        { 'api_version' => manifest['api_version'] }
+      end
+
       def value_for_setting(variable)
         return variable.fetch('value') unless variable.fetch('type') == 'file'
 


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Themes define a `api_version` in the manifest but this wasn't being sent to the server.

### References
* JIRA: [GG-889]

### Risks
* low - only for the themes utility


[GG-889]: https://zendesk.atlassian.net/browse/GG-889