### PR TITLE
Update REGEX for staging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (3.5.0)
+    zendesk_apps_tools (3.5.1)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)

--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -8,7 +8,7 @@ module ZendeskAppsTools
     set :server, :thin
     set :logging, true
     set :protection, except: :frame_options
-    ZENDESK_DOMAINS_REGEX = %r{^http(?:s)?://[a-z0-9-]+\.(?:zendesk|zopim|zd-(?:dev|master|staging))\.com$}
+    ZENDESK_DOMAINS_REGEX = %r{^http(?:s)?://[a-z0-9-]+\.(?:zendesk|zopim|zendesk-(?:dev|master|staging))\.com$}
 
     get '/app.js' do
       serve_installed_js


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
`zd-staging.com` was changed to `zendesk-staging.com` a long time ago. This old regex means `?zat=true` does not function correctly on staging (more specific the reload doesn't work).

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-XXX

### Risks
* [none] only affects staging