### PR TITLE
Use ZAS v4.23.0 in ZAT BUMP v3.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (3.5.1)
+    zendesk_apps_tools (3.6.0)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)
@@ -12,7 +12,7 @@ PATH
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.7.2)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.25.0)
+      zendesk_apps_support (~> 4.26.0)
 
 GEM
   remote: https://rubygems.org/
@@ -142,7 +142,7 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    zendesk_apps_support (4.25.0)
+    zendesk_apps_support (4.26.0)
       erubis
       i18n
       image_size

--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '3.5.1'
+  VERSION = '3.6.0'
 end

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.25.0'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.26.0'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'
   s.add_runtime_dependency 'rack-livereload'


### PR DESCRIPTION
/cc @zendesk/vegemite @zendesk/dingo @jalee-zendesk 

### Description
Bumping ZAS to v2.26.0. In the meantime, bumping ZAT also in the process v3.6.0

### Risks
* [low] Only bumping ZAS for ZAM not for ZAT