### PR TITLE
[APPS-4945]Use ZAS v4.27.0 and BUMP ZAT v3.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 language: ruby
 dist: trusty
+before_install:
+  gem install bundler -v 1.17.3
 rvm:
   - 2.1
   - 2.2.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (3.6.0)
+    zendesk_apps_tools (3.6.1)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)
@@ -12,7 +12,7 @@ PATH
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.7.2)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.25.0)
+      zendesk_apps_support (~> 4.27.0)
 
 GEM
   remote: https://rubygems.org/
@@ -142,7 +142,7 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    zendesk_apps_support (4.25.0)
+    zendesk_apps_support (4.27.0)
       erubis
       i18n
       image_size

--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '3.6.0'
+  VERSION = '3.6.1'
 end

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.25.0'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.27.0'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'
   s.add_runtime_dependency 'rack-livereload'


### PR DESCRIPTION
/cc @zendesk/dingo 

### Description
[JIRA story](https://zendesk.atlassian.net/browse/APPS-4945).
In this implementation, I have added a before_install script `gem install bundler -v 1.17.3` because that is the current default bundler version that supports ruby version 2.1 through to 2.4

<img width="354" alt="Screen Shot 2020-01-10 at 10 47 03 am" src="https://user-images.githubusercontent.com/17760485/72114099-9ff58480-3396-11ea-9f29-2cb4e0ba5963.png">


Also, we need ZAS bumped to support custom objects when it becomes available.

### Risks
* [low] Bumping ZAS in ZAT. 
