### PR TITLE
Allow futuresimple for CORS

### DIFF
--- a/lib/zendesk_apps_tools/server.rb
+++ b/lib/zendesk_apps_tools/server.rb
@@ -8,7 +8,7 @@ module ZendeskAppsTools
     set :server, :thin
     set :logging, true
     set :protection, except: :frame_options
-    ZENDESK_DOMAINS_REGEX = %r{^http(?:s)?://[a-z0-9-]+\.(?:zendesk|zopim|zendesk-(?:dev|master|staging))\.com$}
+    ZENDESK_DOMAINS_REGEX = %r{^http(?:s)?://[a-z0-9-]+\.(?:zendesk|zopim|futuresimple|local.futuresimple|zendesk-(?:dev|master|staging))\.com$}
 
     get '/app.js' do
       serve_installed_js


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Allow `futuresimple` and `local.futuresimple` in the regex, so they will get CORS headers when using `?zat=true`

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-XXX

### Risks
* [none] Added new domains to regex