### PR TITLE
Bump of zendesk_apps_support dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.7.2)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.28.0)
+      zendesk_apps_support (~> 4.29.2)
 
 GEM
   remote: https://rubygems.org/
@@ -32,7 +32,7 @@ GEM
     celluloid (0.16.0)
       timers (~> 4.0.0)
     childprocess (3.0.0)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     contracts (0.16.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -79,7 +79,7 @@ GEM
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mimemagic (0.3.4)
+    mimemagic (0.3.5)
     mini_portile2 (2.3.0)
     multi_json (1.14.1)
     multi_test (0.1.2)
@@ -87,13 +87,13 @@ GEM
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     public_suffix (4.0.3)
-    rack (1.6.12)
+    rack (1.6.13)
     rack-livereload (0.3.17)
       rack
     rack-protection (1.5.5)
       rack
     rake (13.0.1)
-    rb-fsevent (0.10.3)
+    rb-fsevent (0.10.4)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rspec (3.9.0)
@@ -140,7 +140,7 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
-    zendesk_apps_support (4.28.0)
+    zendesk_apps_support (4.29.2)
       erubis
       i18n
       image_size

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.28.0'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.29.2'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'
   s.add_runtime_dependency 'rack-livereload'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Bumping zendesk_apps_support version in order to get new available location `visit_editor` from zendesk_apps_support's latest release

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Write tests
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)

### References
* JIRA: https://zendesk.atlassian.net/browse/SFP-841

### Risks
* [low] Does it work on windows? Should not be affected
* [low] Does it work in the different products (Support, Chat)? Should not be affected
* [low] Are there any performance implications? No
* [low] Any security risks? No
* [low] What features does this touch? Locations update
