### PR TITLE
Inject script in footer if theme is using theming v2 api

### DIFF
--- a/lib/zendesk_apps_tools/theme.rb
+++ b/lib/zendesk_apps_tools/theme.rb
@@ -90,8 +90,15 @@ module ZendeskAppsTools
           identifier = template.match(IDENTIFIER_REGEX)['identifier'].to_s
           templates_payload[identifier] = File.read(template)
         end
+        #template where inject_external_tags will inject scripts/tags
+        script_location = 'document_head'
+        #use footer as location for tag injections 
+        if metadata_hash['api_version'] == 2
+          script_location = 'footer'
+        end
         payload['templates'] = templates_payload
-        payload['templates']['document_head'] = inject_external_tags(payload['templates']['document_head'])
+        #inject tag in either document_head (theming_v1 based themes), or footer (theming_v2 based themes)
+        payload['templates'][script_location] = inject_external_tags(payload['templates'][script_location])
         payload['templates']['css'] = ''
         payload['templates']['js'] = ''
         payload['templates']['assets'] = assets


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
As mentioned in #339 

The theme preview is injecting script.js in document_head template which was fine for theming_v1  based themes. 

The theming_v2 themes will now have script.js at the end of the page. That means, people need to do some work to migrate their javascript to adopt to this new situation (script.js loads at the end), and test.

This must be fixed to make sure we can have similar (if not same) locally. The order of script matters a lot, and if it's not right it leads to issues. 

I have made the change to check api_version, and change the template where script is injected.


### Tasks
- [x] Include comments/inline docs where appropriate
- [ ] Write tests
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-XXX

### Risks
* [HIGH | medium | low] Does it work on windows? Unable to verify
* [HIGH | medium | low] Does it work in the different products (Support, Chat)? End User Request form from Support
* [HIGH | medium | low] Are there any performance implications? No
* [HIGH | medium | low] Any security risks? No
* [HIGH | medium | low] What features does this touch? Local Theme Preview
