### PR TITLE
Fix Apache license SPDX identifier

### DIFF
--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.version     = ZendeskAppsTools::VERSION
   s.executables << 'zat'
   s.platform    = Gem::Platform::RUBY
-  s.license     = 'Apache License Version 2.0'
+  s.license     = 'Apache-2.0'
   s.authors     = ['James A. Rosen', 'Kenshiro Nakagawa', 'Shajith Chacko', 'Likun Liu']
   s.email       = ['dev@zendesk.com']
   s.homepage    = 'http://github.com/zendesk/zendesk_apps_tools'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
The Apache license version text is incorrect, and there is a warning thrown during build time. This fix adds valid license identifier as per https://spdx.org/licenses/

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Write tests
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-XXX

### Risks
* [HIGH | medium | low] Does it work on windows? 
* [HIGH | medium | low] Does it work in the different products (Support, Chat)? 
* [HIGH | medium | low] Are there any performance implications?
* [HIGH | medium | low] Any security risks?
* [HIGH | medium | low] What features does this touch?
