### PR TITLE
Bump thin from 1.7.2 to 1.8.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       rubyzip (~> 1.2.1)
       sinatra (~> 1.4.6)
       sinatra-cross_origin (~> 0.3.1)
-      thin (~> 1.7.2)
+      thin (~> 1.8.0)
       thor (~> 0.19.4)
       zendesk_apps_support (~> 4.29.5)
 
@@ -125,7 +125,7 @@ GEM
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     sinatra-cross_origin (0.3.2)
-    thin (1.7.2)
+    thin (1.8.0)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'thor',        '~> 0.19.4'
   s.add_runtime_dependency 'rubyzip',     '~> 1.2.1'
-  s.add_runtime_dependency 'thin',        '~> 1.7.2'
+  s.add_runtime_dependency 'thin',        '~> 1.8.0'
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Failed to build gem dependency(native extensions) thin server on MacOS 10.15.6
Solution is to bump thin version from 1.7.2 to 1.8.0


### References
* https://github.com/macournoyer/thin/issues/370
