### PR TITLE
bump faraday to 1.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     zendesk_apps_tools (3.8.1)
       execjs (~> 2.7.0)
-      faraday (~> 0.9.2)
+      faraday (~> 1.3.0)
       faye-websocket (~> 0.10.7)
       listen (~> 2.10)
       rack-livereload

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rubyzip',     '~> 1.2.1'
   s.add_runtime_dependency 'thin',        '~> 1.7.2'
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
-  s.add_runtime_dependency 'faraday',     '~> 0.9.2'
+  s.add_runtime_dependency 'faraday',     '~> 1.3.0'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
   s.add_runtime_dependency 'zendesk_apps_support', '~> 4.29.5'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Bump faraday to 1.3.0, fixes issue #349

Running the latest ZAT throws warnings like these:
/var/lib/gems/2.7.0/gems/faraday-0.9.2/lib/faraday/options.rb:153: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
