### PR TITLE
[VEG-486] Bump ZAT to 3.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (3.8.1)
+    zendesk_apps_tools (3.8.2)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
     mini_portile2 (2.4.0)
     multi_json (1.14.1)
     multi_test (0.1.2)
@@ -166,4 +166,4 @@ DEPENDENCIES
   zendesk_apps_tools!
 
 BUNDLED WITH
-   1.17.3
+   2.2.24

--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '3.8.1'
+  VERSION = '3.8.2'
 end


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
* Bump ZAT to 3.8.2.
* Bump mimemagic to 0.3.10 since 0.3.5 seems to have been pulled from RubyGems.

### References
* JIRA: https://zendesk.atlassian.net/browse/VEG-486

### Risks
* Medium.  [Minor version gem bump of thin](https://github.com/zendesk/zendesk_apps_tools/pull/354).  Might break anything that requires use of the thin client, like `zat server`.
* Low.  Patch version bump of mimemagic.  I think that this is used for assets, so could break anything involving uploading things, like `zat update`.
