### PR TITLE
[VEG-638] Bump zendesk_apps_support to latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.8.0)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.29.5)
+      zendesk_apps_support (~> 4.29.9)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     celluloid (0.16.0)
       timers (~> 4.0.0)
     childprocess (3.0.0)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.9)
     contracts (0.16.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -63,23 +63,23 @@ GEM
     faye-websocket (0.10.9)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    ffi (1.9.25)
+    ffi (1.15.3)
     gherkin (5.1.0)
     hashdiff (1.0.0)
     hitimes (2.0.0)
-    i18n (1.8.5)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     image_size (2.0.2)
     ipaddress_2 (0.13.0)
-    json (2.3.1)
+    json (2.5.1)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    loofah (2.2.3)
+    loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mimemagic (0.3.10)
+    marcel (1.0.1)
     mini_portile2 (2.4.0)
     multi_json (1.14.1)
     multi_test (0.1.2)
@@ -92,8 +92,8 @@ GEM
       rack
     rack-protection (1.5.5)
       rack
-    rake (13.0.1)
-    rb-fsevent (0.10.4)
+    rake (13.0.6)
+    rb-fsevent (0.11.0)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rspec (3.9.0)
@@ -116,10 +116,8 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sassc (1.11.4)
-      bundler
-      ffi (~> 1.9.6)
-      sass (>= 3.3.0)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -140,18 +138,18 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zendesk_apps_support (4.29.5)
+    zendesk_apps_support (4.29.9)
       erubis
       i18n
       image_size (~> 2.0.2)
       ipaddress_2 (~> 0.13.0)
       json
-      loofah (~> 2.2.3)
-      mimemagic (~> 0.3.3)
+      loofah (~> 2.3.1)
+      marcel
       nokogiri (>= 1.8.5, < 1.11.0)
       rb-inotify (= 0.9.10)
       sass
-      sassc (~> 1.11.2)
+      sassc
 
 PLATFORMS
   ruby
@@ -166,4 +164,4 @@ DEPENDENCIES
   zendesk_apps_tools!
 
 BUNDLED WITH
-   2.2.24
+   2.2.26

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (3.8.2)
+    zendesk_apps_tools (3.8.3)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)

--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '3.8.2'
+  VERSION = '3.8.3'
 end

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.29.5'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.29.9'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'
   s.add_runtime_dependency 'rack-livereload'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Let's bump zendesk_apps_support to 4.29.9, so that we have access to the latest validations.

Compare diff: https://github.com/zendesk/zendesk_apps_support/compare/v4.29.5...v4.29.9

Changes:
* https://github.com/zendesk/zendesk_apps_support/pull/306, version bump, no risk
* https://github.com/zendesk/zendesk_apps_support/pull/304, Add warning for sensitive data in hidden fields, low risk: validations might break.
* https://github.com/zendesk/zendesk_apps_support/pull/303, Add strings for new warning validation, no risk: translations only
* https://github.com/zendesk/zendesk_apps_support/pull/305, Replace mime_type gem with marcel, low risk: drop in gem replacement
* https://github.com/zendesk/zendesk_apps_support/pull/301, version bump, no risk.
* https://github.com/zendesk/zendesk_apps_support/pull/300, version bump, no risk
* https://github.com/zendesk/zendesk_apps_support/pull/297, loofah gem bump to placate snyk, low risk
* https://github.com/zendesk/zendesk_apps_support/pull/291, alter bundler versions, no risk
* https://github.com/zendesk/zendesk_apps_support/pull/289, bump [saasc](https://github.com/sass/sassc-ruby), medium risk
* https://github.com/zendesk/zendesk_apps_support/pull/288, version bump, no risk
* https://github.com/zendesk/zendesk_apps_support/pull/309, github action, no risk
* https://github.com/zendesk/zendesk_apps_support/pull/308, flexible: true validation change, low risk
* https://github.com/zendesk/zendesk_apps_support/pull/310, gem bump + bundler bump, no risk

4 low risks, 1 medium risk.  Overall risk: medium.

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Write tests
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)

### References
* JIRA: https://zendesk.atlassian.net/browse/VEG-638

### Risks
Medium. A large number of changes for ZAS being brought in. A bit unavoidable, unless we cherrypick the flexible: true change to a separate tag.  These risks are:
* https://github.com/zendesk/zendesk_apps_support/pull/289, bump [saasc](https://github.com/sass/sassc-ruby), medium risk
* https://github.com/zendesk/zendesk_apps_support/pull/304, Add warning for sensitive data in hidden fields, low risk: validations might break.
* https://github.com/zendesk/zendesk_apps_support/pull/305, Replace mime_type gem with marcel, low risk: drop in gem replacement
* https://github.com/zendesk/zendesk_apps_support/pull/297, loofah gem bump to placate snyk, low risk
* https://github.com/zendesk/zendesk_apps_support/pull/308, flexible: true validation change, low risk

Given the level of risk, the following things should be checked before merging this PR:
* `zat server` with an app should still work.
* `zat validate` should work for happy and for failure mode paths
* `zat package` should still work, as should `zat new`
* `zat create` and `zat update` should still work.