### PR TITLE
[VEG-601] Add support for new flexible parameter for the most default of scaffolds

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Describe the original problem and the changes made on this PR.
 - [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)
 
 ### References
-* JIRA: https://zendesk.atlassian.net/browse/AF-XXX
+* JIRA: https://zendesk.atlassian.net/browse/VEG-XXX
 
 ### Risks
 * [HIGH | medium | low] Does it work on windows?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (3.8.3)
+    zendesk_apps_tools (3.8.4)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)

--- a/app_template_iframe/manifest.json.tt
+++ b/app_template_iframe/manifest.json.tt
@@ -9,7 +9,8 @@
   "private": true,
   "location": {
     "support": {
-      "ticket_sidebar": "<%= @iframe_location %>"
+      "ticket_sidebar": "<%= @iframe_location %>",
+      "flexible": true
     }
   },
   "version": "1.0",

--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '3.8.3'
+  VERSION = '3.8.4'
 end


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
* Add support for new flexible parameter for the most default of scaffolds.
* Bump the version
* Alter the github template to VEG instead of AF 🥦 

### References
* VEG-601: https://zendesk.atlassian.net/browse/VEG-601

### Risks
* Low. Adds a new attribute only. New apps might not pass `zat validate` by default.
