### PR TITLE
Lock racc to 1.5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)
       listen (~> 2.10)
+      racc (~> 1.5.2)
       rack-livereload
       rubyzip (~> 1.2.1)
       sinatra (~> 1.4.6)
@@ -87,6 +88,7 @@ GEM
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     public_suffix (4.0.3)
+    racc (1.5.2)
     rack (1.6.13)
     rack-livereload (0.3.17)
       rack

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
+  s.add_runtime_dependency 'racc',        '~> 1.5.2'
   s.add_runtime_dependency 'zendesk_apps_support', '~> 4.29.9'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
We need to lock racc to 1.5.2 to facilitate particular user workflows.

### Risks
* Low. Might break ZAT for various usecases.
