### PR TITLE
Added force_polling option into theme.rb

### DIFF
--- a/lib/zendesk_apps_tools/theme.rb
+++ b/lib/zendesk_apps_tools/theme.rb
@@ -13,6 +13,7 @@ module ZendeskAppsTools
     method_option :port, default: Command::DEFAULT_SERVER_PORT, required: false, desc: 'Port for the http server to use.'
     method_option :bind, required: false
     method_option :livereload, type: :boolean, default: true, desc: 'Enable or disable live-reloading the preview when a change is made.'
+    method_option :force_polling, type: :boolean, default: false, desc: 'Force the use of the polling adapter.'
     def preview
       setup_path(options[:path])
       ensure_manifest!
@@ -62,7 +63,7 @@ module ZendeskAppsTools
         # TODO: do we need to stop the listener at some point?
         require 'listen'
         path = Pathname.new(theme_package_path('.')).cleanpath
-        listener = ::Listen.to(path, ignore: /\.zat/) do |modified, added, removed|
+        listener = ::Listen.to(path, ignore: /\.zat/, force_polling: options[:force_polling]) do |modified, added, removed|
           need_upload = false
           if modified.any? { |file| file[/templates|manifest/] }
             need_upload = true


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description

Im using zendesk_app_tools via vm which mount volume via sshfs. 

I see that you using [listen gem](https://github.com/guard/listen) to manage theme file changes.

Its readme says  

> some filesystems won't work without polling (VM/Vagrant Shared folders, NFS, Samba, sshfs, etc.)

Thats why I added --force-polling option into `zat theme preview`.

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Write tests
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)

### Risks
* [HIGH | medium | low] Does it work on windows?
* [HIGH | medium | low] Does it work in the different products (Support, Chat)?
* [HIGH | medium | low] Are there any performance implications?
* [HIGH | medium | low] Any security risks?
* [HIGH | medium | low] What features does this touch?
