### PR TITLE
[VEG-1069] Bump zendesk_apps_support to 4.31.1

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.6.9, 2.6.8, 2.5.9]
+        ruby-version: [2.7.5, 2.6.9, 2.6.8]
     steps:
     - uses: zendesk/checkout@v2
     - uses: zendesk/setup-ruby@v1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (3.8.5)
+    zendesk_apps_tools (3.8.6)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.10.7)
@@ -12,7 +12,7 @@ PATH
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.8.0)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.29.9)
+      zendesk_apps_support (~> 4.31.1)
 
 GEM
   remote: https://rubygems.org/
@@ -53,7 +53,7 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    daemons (1.3.1)
+    daemons (1.4.1)
     diff-lcs (1.3)
     erubis (2.7.0)
     eventmachine (1.2.7)
@@ -67,11 +67,11 @@ GEM
     gherkin (5.1.0)
     hashdiff (1.0.0)
     hitimes (2.0.0)
-    i18n (1.8.10)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     image_size (2.0.2)
     ipaddress_2 (0.13.0)
-    json (2.5.1)
+    json (2.6.1)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
@@ -79,21 +79,23 @@ GEM
     loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    marcel (1.0.1)
-    mini_portile2 (2.4.0)
+    marcel (1.0.2)
+    mini_portile2 (2.7.1)
     multi_json (1.14.1)
     multi_test (0.1.2)
     multipart-post (2.1.1)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.13.1)
+      mini_portile2 (~> 2.7.0)
+      racc (~> 1.4)
     public_suffix (4.0.3)
+    racc (1.6.0)
     rack (1.6.13)
     rack-livereload (0.3.17)
       rack
     rack-protection (1.5.5)
       rack
     rake (13.0.6)
-    rb-fsevent (0.11.0)
+    rb-fsevent (0.11.1)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rspec (3.9.0)
@@ -123,7 +125,7 @@ GEM
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     sinatra-cross_origin (0.3.2)
-    thin (1.8.0)
+    thin (1.8.1)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
@@ -135,10 +137,10 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.7.3)
+    websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zendesk_apps_support (4.29.9)
+    zendesk_apps_support (4.31.1)
       erubis
       i18n
       image_size (~> 2.0.2)
@@ -146,7 +148,7 @@ GEM
       json
       loofah (~> 2.3.1)
       marcel
-      nokogiri (>= 1.8.5, < 1.11.0)
+      nokogiri
       rb-inotify (= 0.9.10)
       sass
       sassc

--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '3.8.5'
+  VERSION = '3.8.6'
 end

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.29.9'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.31.1'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'
   s.add_runtime_dependency 'rack-livereload'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
We should bump zendesk_apps_support to the latest version so that ZAT can validate on Webhook app requirements.

Also drops support for Ruby 2.5 which has been EOL for almost one year now: https://endoflife.date/ruby .  Nokogiri 1.13.1 drops support for Ruby 2.5.9.

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Write tests
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)

### References
* JIRA: https://zendesk.atlassian.net/browse/VEG-1069

### Risks
* Low. Might break validations for app requirements.
