### PR TITLE
[VEG-1234] Apply additional changes to support running in docker

### DIFF
--- a/lib/zendesk_apps_tools/command.rb
+++ b/lib/zendesk_apps_tools/command.rb
@@ -11,6 +11,7 @@ module ZendeskAppsTools
     include ZendeskAppsTools::CommandHelpers
 
     map %w[-v] => :version
+    DEFAULT_SERVER_IP = '0.0.0.0'
     DEFAULT_SERVER_PORT = '4567'
 
     source_root File.expand_path(File.join(File.dirname(__FILE__), '../..'))
@@ -158,7 +159,7 @@ module ZendeskAppsTools
     method_option :config, default: DEFAULT_CONFIG_PATH, required: false, aliases: '-c'
     method_option :port, default: DEFAULT_SERVER_PORT, required: false, desc: 'Port for the http server to use.'
     method_option :app_id, default: DEFAULT_APP_ID, required: false, type: :numeric
-    method_option :bind, required: false
+    method_option :bind, default: DEFAULT_SERVER_IP, required: false
     method_option :plan, required: false
     def server
       setup_path(options[:path])

--- a/lib/zendesk_apps_tools/theme.rb
+++ b/lib/zendesk_apps_tools/theme.rb
@@ -11,7 +11,7 @@ module ZendeskAppsTools
     desc 'preview', 'Preview a theme in development'
     shared_options(except: %i[clean unattended])
     method_option :port, default: Command::DEFAULT_SERVER_PORT, required: false, desc: 'Port for the http server to use.'
-    method_option :bind, required: false
+    method_option :bind, default: Command::DEFAULT_SERVER_IP, required: false
     method_option :livereload, type: :boolean, default: true, desc: 'Enable or disable live-reloading the preview when a change is made.'
     def preview
       setup_path(options[:path])

--- a/scripts/invoke.sh
+++ b/scripts/invoke.sh
@@ -20,6 +20,7 @@ check_cmd_in_path docker
 # When running the zat container, mount the current directory to /app
 # so that zat has access to it.
 docker run \
+    --network="bridge" \
     --interactive --tty --rm \
     --volume "$PWD":/wd \
     --workdir /wd \


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
The previous change [here](https://github.com/zendesk/zendesk_apps_tools/pull/378) was not quite enough to support running in Docker, sinatra was not exposed from within the container to the outside world.

This change:
* Sets a `DEFAULT_SERVER_IP` of `'0.0.0.0'` as the Sinatra bind ip ([ref](https://forums.docker.com/t/service-running-on-port-4567-only-replies-within-the-container/27166)) for both `server` and `theme` subcommands.
* Sets the default network to `bridge` when running the container.

### References
* JIRA: https://zendesk.atlassian.net/browse/VEG-1234
* https://github.com/zendesk/zendesk_apps_tools/pull/378

### Risks
* Medium.  Might break `zat server` or `zat theme preview` when running on Windows.
