### PR TITLE
[DINGO-1663] Upgrade ZAS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.8.0)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.31.1)
+      zendesk_apps_support (~> 4.32.0)
 
 GEM
   remote: https://rubygems.org/
@@ -100,7 +100,7 @@ GEM
     mime-types-data (3.2022.0105)
     multi_test (0.1.2)
     multipart-post (2.1.1)
-    nokogiri (1.13.4-x86_64-darwin)
+    nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -160,7 +160,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zendesk_apps_support (4.31.1)
+    zendesk_apps_support (4.32.0)
       erubis
       i18n
       image_size (~> 2.0.2)
@@ -175,6 +175,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   aruba

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 1.4.6'
   s.add_runtime_dependency 'faraday',     '~> 0.17.5'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.31.1'
+  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.32.0'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'
   s.add_runtime_dependency 'rack-livereload'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description

Upgrade ZAS to v4.32.0, which will fail validation for apps having http target requirements.

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Write tests
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)

### References
* JIRA: https://zendesk.atlassian.net/browse/DINGO-1663

### Risks
* [HIGH | medium | low] Does it work on windows?
* [HIGH | medium | low] Does it work in the different products (Support, Chat)?
* [HIGH | medium | low] Are there any performance implications?
* [HIGH | medium | low] Any security risks?
* [HIGH | medium | low] What features does this touch?

low, fail validation for apps having http target requirements