### PR TITLE
Bump version + bundle install

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,8 +14,10 @@ Describe the original problem and the changes made on this PR.
 * JIRA: https://zendesk.atlassian.net/browse/VEG-XXX
 
 ### Risks
+<!--
 * [HIGH | medium | low] Does it work on windows?
 * [HIGH | medium | low] Does it work in the different products (Support, Chat)?
 * [HIGH | medium | low] Are there any performance implications?
 * [HIGH | medium | low] Any security risks?
 * [HIGH | medium | low] What features does this touch?
+-->

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (3.8.9)
+    zendesk_apps_tools (3.8.10)
       execjs (~> 2.7.0)
       faraday (~> 0.17.5)
       faye-websocket (>= 0.10.7, < 0.12.0)
@@ -85,7 +85,7 @@ GEM
       concurrent-ruby (~> 1.0)
     image_size (2.0.2)
     ipaddress_2 (0.13.0)
-    json (2.6.1)
+    json (2.6.2)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)

--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '3.8.9'
+  VERSION = '3.8.10'
 end


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
* Bump the version of zendesk_apps_tools to 3.8.10
* Ensure that the repo is bundled to pick up the latest versions of dependencies
* Clarify risks in GH template so that these are prompts for authors only + do not get exposed within pull request opening comments

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Write tests
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)

### References
* JIRA: https://zendesk.atlassian.net/browse/VEG-XXX

### Risks
* Low. Might break ZAT validation due to changes to Gemfile.lock.
