### PR TITLE
Add bundler-audit and bundler-audit-fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       sinatra (>= 1.4.6, < 2.3.0)
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.8.0)
-      thor (~> 0.19.4)
+      thor (~> 1.2.1)
       zendesk_apps_support (~> 4.32.0)
 
 GEM
@@ -19,19 +19,26 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    aruba (0.14.14)
-      childprocess (>= 0.6.3, < 4.0.0)
-      contracts (~> 0.9)
-      cucumber (>= 1.3.19)
-      ffi (~> 1.9)
-      rspec-expectations (>= 2.99)
-      thor (>= 0.19, < 2.0)
+    aruba (2.0.1)
+      bundler (>= 1.17, < 3.0)
+      childprocess (>= 2.0, < 5.0)
+      contracts (>= 0.16.0, < 0.18.0)
+      cucumber (>= 4.0, < 8.0)
+      rspec-expectations (~> 3.4)
+      thor (~> 1.0)
     builder (3.2.4)
     bump (0.10.0)
+    bundler-audit (0.9.0.1)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
+    bundler-audit-fix (0.3.0)
+      bundler (>= 1.2.0, < 3)
+      bundler-audit (~> 0.9.0)
+      thor (~> 1.0)
     byebug (11.1.3)
     celluloid (0.16.0)
       timers (~> 4.0.0)
-    childprocess (3.0.0)
+    childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     contracts (0.16.1)
@@ -98,17 +105,17 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
-    mini_portile2 (2.4.0)
     multi_test (0.1.2)
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.13.6-x86_64-darwin)
+      racc (~> 1.4)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.7)
+    racc (1.6.0)
     rack (2.2.3)
     rack-livereload (0.3.17)
       rack
@@ -153,7 +160,7 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    thor (0.19.4)
+    thor (1.2.1)
     tilt (2.0.10)
     timers (4.0.4)
       hitimes
@@ -178,13 +185,13 @@ GEM
       sassc
 
 PLATFORMS
-  x86_64-darwin-20
   x86_64-darwin-21
-  x86_64-linux
 
 DEPENDENCIES
   aruba
   bump
+  bundler-audit
+  bundler-audit-fix
   byebug
   cucumber
   pry
@@ -194,4 +201,4 @@ DEPENDENCIES
   zendesk_apps_tools!
 
 BUNDLED WITH
-   2.2.26
+   2.3.13

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3'
   s.required_rubygems_version = '>= 1.3.6'
 
-  s.add_runtime_dependency 'thor',        '~> 0.19.4'
+  s.add_runtime_dependency 'thor',        '~> 1.2.1'
   s.add_runtime_dependency 'rubyzip',     '>= 1.2.1', '< 2.4.0'
   s.add_runtime_dependency 'thin',        '~> 1.8.0'
   s.add_runtime_dependency 'sinatra',     '>= 1.4.6', '< 2.3.0'
@@ -27,6 +27,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rack-livereload'
   s.add_runtime_dependency 'faye-websocket', '>= 0.10.7', '< 0.12.0'
 
+  s.add_development_dependency 'bundler-audit'
+  s.add_development_dependency 'bundler-audit-fix'
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'aruba'
   s.add_development_dependency 'rspec'
@@ -35,7 +37,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bump'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'rake'
-
 
   s.files        = Dir.glob('{bin,lib,app_template*,templates}/**/*') + %w[README.md LICENSE]
   s.test_files   = Dir.glob('features/**/*')


### PR DESCRIPTION
### Description

Adds tools for auditing vulnerabilities for ZAT. This is important in
order to make sure that we ship secure code.

As part of this change I needed to bump the major version of Thor, which
is a gem used to handle the command line functionality for ZAT.

When running bundler-audit-fix one can run

`bundle exec bundler-audit-fix update .` `[1]`

This should address vulnerabilities identified by `bundler-audit`.

`[1]`: https://github.com/nobuyo/bundler-audit-fix

:v:

/cc @zendesk/vegemite

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Write tests
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)

### References
* tbd

### Risks
<!--
* [HIGH | medium | low] Does it work on windows?
* [HIGH | medium | low] Does it work in the different products (Support, Chat)?
* [HIGH | medium | low] Are there any performance implications?
* [HIGH | medium | low] Any security risks?
* [HIGH | medium | low] What features does this touch?
-->
Medium. Might break the command line functionality of ZAT as Thor, the library which powers the CLI, has been bumped by a major version.  This should be easy to check though -- if one builds the gem manually and run `./bin/zat version`, then things should still work.