### PR TITLE
Downgrade json to 2.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (3.8.10)
+    zendesk_apps_tools (3.8.11)
       execjs (~> 2.7.0)
       faraday (~> 0.17.5)
       faye-websocket (>= 0.10.7, < 0.12.0)
@@ -85,7 +85,7 @@ GEM
       concurrent-ruby (~> 1.0)
     image_size (2.0.2)
     ipaddress_2 (0.13.0)
-    json (2.6.2)
+    json (2.6.1)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)

--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '3.8.10'
+  VERSION = '3.8.11'
 end


### PR DESCRIPTION
We should lock json at 2.6.1 since it appears that the patch version
bump to json 2.6.2 broke certain functionality handling errors in ZAT,
by causing a panic + broken flow of execution in certain usecases.

:v:

/cc @zendesk/vegemite

### References
* PR that bumped JSON: https://github.com/zendesk/zendesk_apps_tools/pull/387

### Risks
<!--
* [HIGH | medium | low] Does it work on windows?
* [HIGH | medium | low] Does it work in the different products (Support, Chat)?
* [HIGH | medium | low] Are there any performance implications?
* [HIGH | medium | low] Any security risks?
* [HIGH | medium | low] What features does this touch?
-->
Medium. This includes the dependabot change [here](https://github.com/zendesk/zendesk_apps_tools/pull/385) so handle with care.

### QA

* Check out this branch
* Run `./bin/zat version`, `./bin/zat server`, `./bin/zat new`.  Check things work.