### PR TITLE
Bump Ruby version and ZAT version

### DIFF
--- a/lib/zendesk_apps_tools/version.rb
+++ b/lib/zendesk_apps_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ZendeskAppsTools
-  VERSION = '3.8.15.beta.3'
+  VERSION = '3.9.0'
 end

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Tools to help you develop Zendesk Apps.'
   s.description = s.summary
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.6'
   s.required_rubygems_version = '>= 1.3.6'
 
   s.add_runtime_dependency 'thor',        '~> 0.19.4'

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = s.summary
 
   s.required_ruby_version = '>= 2.6'
-  s.required_rubygems_version = '>= 1.3.6'
+  s.required_rubygems_version = '>= 3.0.0'
 
   s.add_runtime_dependency 'thor',        '~> 0.19.4'
   s.add_runtime_dependency 'rubyzip',     '>= 1.2.1', '< 2.4.0'


### PR DESCRIPTION
<!-- :v: -->
<!--  -->
<!-- /cc @zendesk/vegemite -->

### Description

- Bump required Ruby to >= 2.6
- Bump required RubyGems version to 3.0.0
- Bump version to 3.9.0

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Write tests
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)

### References
* JIRA: N/A

### Risks
<!--
* [HIGH | medium | low] Does it work on windows?
* [HIGH | medium | low] Does it work in the different products (Support, Chat)?
* [HIGH | medium | low] Are there any performance implications?
* [HIGH | medium | low] Any security risks?
* [HIGH | medium | low] What features does this touch?
-->
Low: We've actually been using nokogiri 1.13.x for a while so ZAT
already requires Ruby >= 2.6.
