### PR TITLE
Fix version in Gemfile.lock being out-of-sync

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -26,6 +26,7 @@ jobs:
         key: ${{ runner.os }}-vendor
     - name: before_script
       run: |
+        bundle config set frozen true
         bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
         gem build zendesk_apps_tools.gemspec
         GEM_VERSION="$(sed -En "s/^.*VERSION = '([[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+(\\.(beta|pre|rc)([[:digit:]]+|\\.?[[:digit:]]+)?)?)'$/\\1/p" lib/zendesk_apps_tools/version.rb)"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_tools (3.8.15.beta.3)
+    zendesk_apps_tools (3.9.0)
       execjs (~> 2.7.0)
       faraday (~> 0.17.5)
       faye-websocket (>= 0.10.7, < 0.12.0)


### PR DESCRIPTION

### Description
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`74cfa25`](https://github.com/zendesk/zendesk_apps_tools/pull/402/commits/74cfa255e419c12c353ab769203d2306baca8b6b) Bundle config frozen to ensure lock file is up-to-date



### [`2b6fa9e`](https://github.com/zendesk/zendesk_apps_tools/pull/402/commits/2b6fa9e407be5a078f13359076ba4aa084c1d3d5) Fix version in Gemfile.lock being out-of-sync

This was an oopsie in my [1]. It doesn't affect `gem install` so only
bringing the lock file to sync without bumping version.

[1] https://github.com/zendesk/zendesk_apps_tools/commit/470a8d6e010970d7b9646304c3b7e17d10694409


<!-- === GH HISTORY FENCE === -->

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Write tests
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)

### References
* JIRA: N/A

### Risks
<!--
* [HIGH | medium | low] Does it work on windows?
* [HIGH | medium | low] Does it work in the different products (Support, Chat)?
* [HIGH | medium | low] Are there any performance implications?
* [HIGH | medium | low] Any security risks?
* [HIGH | medium | low] What features does this touch?
-->
Low: Fixing only version number in the lock file.
