### PR TITLE
Bump listen to 3.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       execjs (~> 2.7.0)
       faraday (~> 0.17.5)
       faye-websocket (>= 0.10.7, < 0.12.0)
-      listen (~> 2.10)
+      listen (~> 3.7.1)
       rack-livereload
       rubyzip (>= 1.2.1, < 2.4.0)
       sinatra (>= 1.4.6, < 2.3.0)
@@ -29,8 +29,6 @@ GEM
     builder (3.2.4)
     bump (0.10.0)
     byebug (11.1.3)
-    celluloid (0.16.0)
-      timers (~> 4.0.0)
     childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -80,16 +78,14 @@ GEM
       websocket-driver (>= 0.5.1)
     ffi (1.15.5)
     hashdiff (1.0.1)
-    hitimes (2.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     image_size (2.0.2)
     ipaddress_2 (0.13.0)
     json (2.6.2)
-    listen (2.10.1)
-      celluloid (~> 0.16.0)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
+    listen (3.7.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -157,8 +153,6 @@ GEM
       rack (>= 1, < 3)
     thor (0.19.4)
     tilt (2.0.10)
-    timers (4.0.4)
-      hitimes
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -196,4 +190,4 @@ DEPENDENCIES
   zendesk_apps_tools!
 
 BUNDLED WITH
-   2.2.26
+   2.3.13

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
   s.add_runtime_dependency 'zendesk_apps_support', '~> 4.36.0'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
-  s.add_runtime_dependency 'listen', '~> 2.10'
+  s.add_runtime_dependency 'listen', '~> 3.7.1'
   s.add_runtime_dependency 'rack-livereload'
   s.add_runtime_dependency 'faye-websocket', '>= 0.10.7', '< 0.12.0'
 


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
[It has been reported](https://github.com/zendesk/zendesk_apps_tools/issues/364#issuecomment-1296287312) that bumping listen to 3.7.1 should fix this issue: https://github.com/zendesk/zendesk_apps_tools/issues/364.

Compare diff: https://github.com/guard/listen/compare/v2.10.1...v3.7.1

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Write tests
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)

### References
* JIRA: https://zendesk.atlassian.net/browse/tbd
* https://github.com/zendesk/zendesk_apps_tools/issues/364

### Risks
High. Might break `zat server` and `zat theme preview` functionality; anything that live reloads from the file system in order to serve an object to a target account.  However, it should be easy enough to check that the functionality still works after this gem bump.
