### PR TITLE
Switch to trusted publishing workflow and run it on version.rb changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,26 @@
-name: Ruby Gem Publish
+name: Publish to RubyGems.org
 
 on:
   push:
-    tags:
-      - v*
+    branches: main
+    paths: lib/zendesk_apps_tools/version.rb
+  workflow_dispatch:
 
 jobs:
   publish:
-    name: Publish to rubygems.org
-    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
-    secrets:
-      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
-      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}
+    runs-on: ubuntu-latest
+    environment: rubygems-publish
+    if: github.repository_owner == 'zendesk'
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: false
+          
+      - name: Install dependencies
+        run: bundle install
+      - uses: rubygems/release-gem@v1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Zendesk Apps Tools is in maintenance mode. This means no additional feature enhancements or non-security bugs will be fixed. **We recommend switching to using [ZCLI](https://github.com/zendesk/zcli) for our best CLI experience.**
 
-
 # Zendesk Apps Tools
 
 ## Description
@@ -40,10 +39,20 @@ Then, comment-out the line referring to `zendesk_apps_support` in this project's
 
 The path should point to your local ZAS directory. In this way, your clone of ZAT will use a local version of ZAS, which is very helpful for development. Run a `bundle install` after changing the Gemfile.
 
-## Deploy ZAT
+## Releasing a new version
+A new version is published to RubyGems.org every time a change to `version.rb` is pushed to the `main` branch.
+In short, follow these steps:
+1. Update `version.rb`,
+2. run `bundle lock` to update `Gemfile.lock`,
+3. merge this change into `main`, and
+4. look at [the action](https://github.com/zendesk/zendesk_apps_tools/actions/workflows/publish.yml) for output.
 
-* To bump ZAT version, run `bump patch|minor|major --no-bundle` from the root directory. **Note:** `--no-bundle` is required in order to prevent `bundle update` command from running, which is by default triggered by the [bump](https://github.com/gregorym/bump) gem and could lead to incompatible dependencies.
-* To publish ZAT to [Rubygems](https://rubygems.org/gems/zendesk_apps_tools), run `bundle exec rake release`.
+To create a pre-release from a non-main branch:
+1. change the version in `version.rb` to something like `1.2.0.pre.1` or `2.0.0.beta.2`,
+2. push this change to your branch,
+3. go to [Actions → “Publish to RubyGems.org” on GitHub](https://github.com/zendesk/zendesk_apps_tools/actions/workflows/publish.yml),
+4. click the “Run workflow” button,
+5. pick your branch from a dropdown.
 
 ## Testing
 This project uses rspec, which you can run with `bundle exec rake`.

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'bundler/setup'
 require 'bundler/gem_tasks'
 require 'rake/clean'
 require 'cucumber/rake/task'

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'rake'
 
-
   s.files        = Dir.glob('{bin,lib,app_template*,templates}/**/*') + %w[README.md LICENSE]
   s.test_files   = Dir.glob('features/**/*')
   s.require_path = 'lib'


### PR DESCRIPTION
Switches to [a Trusted Publishing workflow](https://guides.rubygems.org/trusted-publishing/).
This workflow will run whenever `version.rb` is changed in the `main` branch.
Setting `ENV["gem_push"]` is also not necessary anymore.
This workflow relies on the main branch being named `main`. Please rename it (`main` is the standard name across Zendesk).
`bundler-cache` for `setup-ruby` is set to false to prevent [cache poisoning attacks](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/).
Finally, we add a description of the new release process. Our README and CONTRIBUTING files don’t have a standard structure, so please check that we have updated a correct file and that the new section makes sense for this gem.
- [ ] Release description has been updated correctly.
- [ ] The main branch is renamed from `master` to `main`.